### PR TITLE
Fix/add job index per user

### DIFF
--- a/.github/workflows/reusable-backend-integration-tests.yml
+++ b/.github/workflows/reusable-backend-integration-tests.yml
@@ -29,7 +29,12 @@ jobs: # Job definitions for callers to inherit
 
             - name: Run integration tests # Vitest loads .env.integration.test → localhost:27017 Compose mongo (replica set)
               run: >-
-                  npx vitest run --config vitest.integration.config.mjs --reporter=default --reporter=github-actions --reporter=junit --outputFile.junit=test-results/junit-integration.xml
+                  npx vitest run \
+                    --config vitest.integration.config.mjs \
+                    --reporter=verbose \
+                    --reporter=github-actions \
+                    --reporter=junit \
+                    --outputFile.junit=test-results/junit-integration.xml
 
 
             - name: Upload JUnit and test results

--- a/backend/.agents/rules/database.mdc
+++ b/backend/.agents/rules/database.mdc
@@ -49,6 +49,7 @@ return result.data;
 ## Unique Constraints
 
 - The `users` collection has a unique index on `email`.
+- The `jobs` collection has a unique compound index on `{ userId, name }` (names are unique per user, not globally).
 - MongoDB code `11000` (duplicate key) is handled automatically by `exceptionsMiddleware` → `ConflictException`.
 - DO NOT manually catch `11000` in controllers or repositories.
 

--- a/backend/.agents/skills/database-query-patterns/SKILL.md
+++ b/backend/.agents/skills/database-query-patterns/SKILL.md
@@ -188,6 +188,7 @@ async getById(id: string, userId: string) {
 - **Transactions require a replica set**: The Docker Compose stack provisions MongoDB with `rs0`. Standalone instances do not support transactions — ensure the integration test environment uses the replica set config.
 - **`isCommitted` guard**: If `commitTransaction()` itself throws (rare but possible), the transaction is in an unknown state. The `isCommitted = true` assignment is placed immediately after the await to minimize the gap.
 - **MongoDB 11000**: Duplicate unique key errors are caught and converted to `ConflictException` by `exceptionsMiddleware` automatically — do not manually catch code `11000` in repositories.
+- **Job name uniqueness**: Enforced by a compound unique index on `{ userId, name }` (see `aop/db/mongo/config`). Different users may share a name; duplicates within one user surface as `11000` → `409 CONFLICT_ERROR`.
 - **ObjectId conversion**: MongoDB `_id` is `ObjectId`; controllers need a string `id`. Convert with `doc._id.toString()` in the repository return value.
 
 # Anti-Patterns

--- a/backend/src/aop/db/mongo/client/client.test.ts
+++ b/backend/src/aop/db/mongo/client/client.test.ts
@@ -383,7 +383,8 @@ describe('MongoClientManager', () => {
             await dbInstance.connect();
 
             // Verify: All collections checked, but only collections without indexes were created
-            expect(mockIndexes).toHaveBeenCalledTimes(collections.length);
+            // TODO: remove + 1
+            expect(mockIndexes).toHaveBeenCalledTimes(collections.length + 1);
             expect(mockCreateIndex).toHaveBeenCalledTimes(collections.length - 1); // Only for collections without index
         });
 

--- a/backend/src/aop/db/mongo/client/client.test.ts
+++ b/backend/src/aop/db/mongo/client/client.test.ts
@@ -383,8 +383,7 @@ describe('MongoClientManager', () => {
             await dbInstance.connect();
 
             // Verify: All collections checked, but only collections without indexes were created
-            // TODO: remove + 1
-            expect(mockIndexes).toHaveBeenCalledTimes(collections.length + 1);
+            expect(mockIndexes).toHaveBeenCalledTimes(collections.length);
             expect(mockCreateIndex).toHaveBeenCalledTimes(collections.length - 1); // Only for collections without index
         });
 

--- a/backend/src/aop/db/mongo/client/client.test.ts
+++ b/backend/src/aop/db/mongo/client/client.test.ts
@@ -233,6 +233,34 @@ describe('MongoClientManager', () => {
             expect(mockDropIndex).toHaveBeenCalledWith('name_1');
         });
 
+        it('should create index when collection namespace does not exist yet', async () => {
+            const namespaceError = new Error('ns does not exist') as MongoError;
+            namespaceError.code = 26;
+
+            mockIndexes.mockRejectedValueOnce(namespaceError).mockImplementation(() => Promise.resolve([]));
+
+            await dbInstance.connect();
+
+            expect(mockCreateIndex).toHaveBeenCalled();
+        });
+
+        it('should not cache db when initializeDb fails so a later connect re-runs initialization', async () => {
+            const initError = new Error('transient index failure');
+
+            mockIndexes.mockRejectedValueOnce(initError).mockImplementation(() => Promise.resolve([]));
+
+            await expect(dbInstance.connect()).rejects.toThrow('transient index failure');
+
+            vi.clearAllMocks();
+            mockIndexes.mockImplementation(() => Promise.resolve([]));
+
+            const db = await dbInstance.connect();
+
+            expect(db).toBe(mockDb);
+            expect(mockCommand).toHaveBeenCalled();
+            expect(mockCreateIndex).toHaveBeenCalled();
+        });
+
         it('should skip creating index when it already exists with correct options', async () => {
             // Mock: indexes exist with correct unique options for all configured collections
             const collections = getIndexedCollections();

--- a/backend/src/aop/db/mongo/client/client.test.ts
+++ b/backend/src/aop/db/mongo/client/client.test.ts
@@ -2,6 +2,9 @@ import { MongoClient, MongoError } from 'mongodb';
 
 import dbConfig from 'aop/db/mongo/config';
 
+import utils from './utils';
+
+import type { CollectionConfig } from '../shared/types';
 import type { MongoClientOptions } from './types';
 
 import { MongoClientManager } from './';
@@ -79,41 +82,25 @@ describe('MongoClientManager', () => {
      *
      * @returns Array of collection configuration items that have index: true
      */
-    const getIndexedCollections = () => {
+    const getIndexedCollections = (): CollectionConfig[] => {
         return Object.values(dbConfig.db.collection).filter(item => item.index);
     };
 
     /**
-     * Helper: Generate expected index name from config item.
-     * Follows MongoDB's naming pattern: {field}_{order} (e.g., email_1, name_1).
-     *
-     * @param item Collection configuration item with targetField and targetValue
-     * @returns Index name string following MongoDB pattern
-     */
-    const getIndexName = (item: { targetField: string; targetValue: number }) => {
-        return `${item.targetField}_${item.targetValue}`;
-    };
-
-    /**
      * Helper: Generate mock index response for a collection based on configuration.
-     * Used to simulate different index states (exists/doesn't exist, correct/wrong options).
-     *
-     * @param item Collection configuration item with index settings
-     * @param exists Whether the index exists in the database
-     * @param correctUnique Whether the unique option matches config (default: true)
-     * @returns Array of index objects (empty if doesn't exist, or single index object if exists)
      */
     const createMockIndex = (
-        item: { targetField: string; targetValue: number; unique: boolean },
+        item: Pick<CollectionConfig, 'indexKeys' | 'unique'>,
         exists: boolean,
-        correctUnique: boolean = true
+        correctUnique: boolean = true,
+        correctKeys: boolean = true
     ) => {
         if (!exists) return [];
 
         return [
             {
-                name: getIndexName(item),
-                key: { [item.targetField]: item.targetValue },
+                name: utils.buildIndexName(item.indexKeys),
+                key: correctKeys ? item.indexKeys : { wrongField: 1 },
                 unique: correctUnique ? item.unique : !item.unique,
             },
         ];
@@ -243,7 +230,7 @@ describe('MongoClientManager', () => {
 
             // Verify createIndex was called for all configured collections
             expect(mockCreateIndex).toHaveBeenCalled();
-            expect(mockDropIndex).not.toHaveBeenCalled();
+            expect(mockDropIndex).toHaveBeenCalledWith('name_1');
         });
 
         it('should skip creating index when it already exists with correct options', async () => {
@@ -262,7 +249,7 @@ describe('MongoClientManager', () => {
 
             // Verify createIndex was not called for any collection (all indexes already exist correctly)
             expect(mockCreateIndex).not.toHaveBeenCalled();
-            expect(mockDropIndex).not.toHaveBeenCalled();
+            expect(mockDropIndex).toHaveBeenCalledWith('name_1');
         });
 
         it('should recreate index when it exists with wrong unique option', async () => {
@@ -287,11 +274,11 @@ describe('MongoClientManager', () => {
             await dbInstance.connect();
 
             // Verify dropIndex and createIndex were called for first collection with conflict
-            expect(mockDropIndex).toHaveBeenCalledWith(getIndexName(firstCollection));
-            expect(mockCreateIndex).toHaveBeenCalledWith(
-                { [firstCollection.targetField]: firstCollection.targetValue },
-                { unique: firstCollection.unique, name: getIndexName(firstCollection) }
-            );
+            expect(mockDropIndex).toHaveBeenCalledWith(utils.buildIndexName(firstCollection.indexKeys));
+            expect(mockCreateIndex).toHaveBeenCalledWith(firstCollection.indexKeys, {
+                unique: firstCollection.unique,
+                name: utils.buildIndexName(firstCollection.indexKeys),
+            });
         });
 
         it('should handle race condition when index is created between check and create', async () => {
@@ -329,7 +316,7 @@ describe('MongoClientManager', () => {
             // First collection: 1 failed attempt + 1 successful recreation after drop = 2 calls
             // Other collections: 1 successful creation each
             const expectedCalls = 1 + 1 + (collections.length - 1); // Failed once, recreated once, other collections once each
-            expect(mockDropIndex).toHaveBeenCalledWith(getIndexName(firstCollection));
+            expect(mockDropIndex).toHaveBeenCalledWith(utils.buildIndexName(firstCollection.indexKeys));
             expect(mockCreateIndex).toHaveBeenCalledTimes(expectedCalls);
         });
 
@@ -359,7 +346,7 @@ describe('MongoClientManager', () => {
 
             // Verify it continued with recreation despite dropIndex failure
             // This ensures resilience when index state changes between check and drop
-            expect(mockDropIndex).toHaveBeenCalledWith(getIndexName(firstCollection));
+            expect(mockDropIndex).toHaveBeenCalledWith(utils.buildIndexName(firstCollection.indexKeys));
             expect(mockCreateIndex).toHaveBeenCalled(); // Should still create index
         });
 
@@ -411,11 +398,49 @@ describe('MongoClientManager', () => {
             // This ensures predictable index names and avoids auto-generated name conflicts
             collections.forEach(item => {
                 expect(mockCreateIndex).toHaveBeenCalledWith(
-                    { [item.targetField]: item.targetValue },
+                    item.indexKeys,
                     expect.objectContaining({
-                        name: getIndexName(item), // Pattern: field_order (e.g., email_1, name_1)
+                        name: utils.buildIndexName(item.indexKeys),
                     })
                 );
+            });
+        });
+
+        it('should drop legacy indexes before creating the configured index', async () => {
+            const collections = getIndexedCollections();
+            const jobsCollection = collections.find(item => item.dropLegacyIndexes?.includes('name_1'));
+
+            expect(jobsCollection).toBeDefined();
+            expect(jobsCollection?.dropLegacyIndexes).toContain('name_1');
+
+            mockIndexes.mockImplementation(() => Promise.resolve([]));
+
+            await dbInstance.connect();
+
+            expect(mockDropIndex).toHaveBeenCalledWith('name_1');
+        });
+
+        it('should recreate index when it exists with wrong key shape', async () => {
+            const collections = getIndexedCollections();
+            const firstCollection = collections[0];
+            let callCount = 0;
+
+            mockIndexes.mockImplementation(() => {
+                const item = collections[callCount];
+                callCount++;
+                if (callCount === 1) {
+                    return Promise.resolve(createMockIndex(item, true, true, false));
+                }
+
+                return Promise.resolve(createMockIndex(item, false));
+            });
+
+            await dbInstance.connect();
+
+            expect(mockDropIndex).toHaveBeenCalledWith(utils.buildIndexName(firstCollection.indexKeys));
+            expect(mockCreateIndex).toHaveBeenCalledWith(firstCollection.indexKeys, {
+                unique: firstCollection.unique,
+                name: utils.buildIndexName(firstCollection.indexKeys),
             });
         });
     });

--- a/backend/src/aop/db/mongo/client/index.ts
+++ b/backend/src/aop/db/mongo/client/index.ts
@@ -11,6 +11,9 @@ import { ErrorMessage } from 'shared/enums/error-messages';
 import type { CollectionConfig } from '../shared/types';
 import type { MongoClientOptions } from './types';
 
+/** MongoDB NamespaceNotFound — collection does not exist yet. */
+const MONGO_NAMESPACE_NOT_FOUND = 26;
+
 /**
  * MongoClientManager is a singleton class responsible for managing the MongoDB client connection.
  * It provides a scalable and testable way to share a MongoDB client across your application,
@@ -52,18 +55,7 @@ export class MongoClientManager {
         }
 
         if (!this.instance && options) {
-            console.log('[DBG:MGR] getInstance: creating new MongoClientManager', {
-                uri: options.uri,
-                dbName: options.dbName,
-            });
             this.instance = new MongoClientManager(options);
-        } else {
-            console.log('[DBG:MGR] getInstance: returning existing instance', {
-                uri: this.instance.uri,
-                dbName: this.instance.dbName,
-                hasClient: !!this.instance.client,
-                hasDb: !!this.instance.db,
-            });
         }
 
         return this.instance;
@@ -85,16 +77,8 @@ export class MongoClientManager {
     async connect(customClient?: MongoClient) {
         // Return existing connection if already established
         if (this.db) {
-            console.log('[DBG:MGR] connect: cache hit, returning existing db', { dbName: this.dbName });
             return this.db;
         }
-
-        console.log('[DBG:MGR] connect: fresh connect starting', {
-            uri: this.uri,
-            dbName: this.dbName,
-            hasCustomClient: !!customClient,
-            hasExistingClient: !!this.client,
-        });
 
         // Use custom client if provided (typically for testing)
         if (customClient) {
@@ -105,17 +89,15 @@ export class MongoClientManager {
         if (!this.client) {
             this.client = new MongoClient(this.uri);
             await this.client.connect();
-            console.log('[DBG:MGR] connect: MongoClient connected', { uri: this.uri });
         }
 
-        // Select the target database
-        this.db = this.client.db(this.dbName);
-        console.log('[DBG:MGR] connect: db selected', { dbName: this.dbName });
+        const db = this.client.db(this.dbName);
 
-        // Initialize database (ping + create indexes)
-        await this.initializeDb(this.db);
+        // Initialize database (ping + create indexes) before caching the Db handle.
+        // Assigning this.db only after success avoids retry/cache-hit skipping init on failure.
+        await this.initializeDb(db);
+        this.db = db;
 
-        console.log('[DBG:MGR] connect: fully initialized, returning db', { dbName: this.dbName });
         return this.db;
     }
 
@@ -127,19 +109,11 @@ export class MongoClientManager {
      * @returns Promise that resolves when disconnection is complete
      */
     async disconnect() {
-        console.log('[DBG:MGR] disconnect: called', {
-            hasClient: !!this.client,
-            hasDb: !!this.db,
-            dbName: this.dbName,
-        });
         if (this.client) {
             await this.client.close();
 
             this.client = null;
             this.db = null;
-            console.log('[DBG:MGR] disconnect: client closed, state cleared');
-        } else {
-            console.log('[DBG:MGR] disconnect: no client to close');
         }
     }
 
@@ -154,6 +128,24 @@ export class MongoClientManager {
         }
 
         return this.client.startSession();
+    }
+
+    /**
+     * Lists indexes for a collection, treating a missing namespace as an empty index list.
+     * On a fresh database, `collection.indexes()` throws NamespaceNotFound before the first write.
+     */
+    private async listCollectionIndexes(collection: Collection) {
+        try {
+            return await collection.indexes();
+        } catch (error) {
+            const mongoError = error as MongoError;
+
+            if (mongoError.code === MONGO_NAMESPACE_NOT_FOUND) {
+                return [];
+            }
+
+            throw error;
+        }
     }
 
     /**
@@ -177,53 +169,29 @@ export class MongoClientManager {
      * @throws Error if database ping fails or index operations fail unrecoverably
      */
     private async initializeDb(db: Db) {
-        console.log('[DBG:INIT] initializeDb: start', { dbName: db.databaseName });
-
         // Verify database connectivity
         logger.info('Pinging database');
 
         await db.command({ ping: 1 });
 
-        console.log('[DBG:INIT] initializeDb: ping ok', { dbName: db.databaseName });
         logger.info('Database pinged');
 
         // Create or update indexes for configured collections
         logger.info('Indexing collections');
 
         const collections = Object.values(config.db.collection).filter(item => item.index);
-        console.log(
-            '[DBG:INIT] initializeDb: collections to index',
-            collections.map(c => ({ name: c.name, indexKeys: c.indexKeys, unique: c.unique }))
-        );
 
         for (const item of collections) {
             const indexName = utils.buildIndexName(item.indexKeys);
             const collection = db.collection(item.name);
-
-            console.log('[DBG:INIT] iter: enter', {
-                collection: item.name,
-                indexName,
-                indexKeys: item.indexKeys,
-                unique: item.unique,
-                dropLegacyIndexes: item.dropLegacyIndexes,
-            });
 
             // Drop legacy indexes if they exist
             if (item.dropLegacyIndexes.length) {
                 for (const legacyIndexName of item.dropLegacyIndexes) {
                     try {
                         await collection.dropIndex(legacyIndexName);
-                        console.log('[DBG:INIT] iter: dropped legacy', {
-                            collection: item.name,
-                            legacyIndexName,
-                        });
                         logger.info(`Dropped legacy index ${legacyIndexName} for ${item.name}`);
                     } catch (dropError) {
-                        console.log('[DBG:INIT] iter: legacy drop skipped (not found)', {
-                            collection: item.name,
-                            legacyIndexName,
-                            message: (dropError as Error).message,
-                        });
                         logger.warn(
                             `Could not drop legacy index ${legacyIndexName} for ${item.name} (may not exist): ${(dropError as Error).message}`
                         );
@@ -233,11 +201,7 @@ export class MongoClientManager {
 
             try {
                 // Check if index already exists
-                const existingIndexes = await collection.indexes();
-                console.log('[DBG:INIT] iter: indexes AFTER drop-legacy / BEFORE create', {
-                    collection: item.name,
-                    indexes: existingIndexes,
-                });
+                const existingIndexes = await this.listCollectionIndexes(collection);
                 const existingIndex = existingIndexes.find(idx => idx.name === indexName);
                 if (existingIndex) {
                     const existingKey = existingIndex.key;
@@ -250,31 +214,13 @@ export class MongoClientManager {
                     const hasSameUniqueOption = existingIndex.unique === item.unique;
 
                     const areIndexesTheSame = hasSameUniqueOption && hasSameFieldCount && hasSameFieldsAndOrder;
-                    console.log('[DBG:INIT] iter: existing index found, comparison', {
-                        collection: item.name,
-                        indexName,
-                        existingKey,
-                        configuredKey,
-                        hasSameFieldCount,
-                        hasSameFieldsAndOrder,
-                        hasSameUniqueOption,
-                        areIndexesTheSame,
-                    });
                     if (areIndexesTheSame) {
                         // Index exists with correct options - no action needed
-                        console.log('[DBG:INIT] iter: skip (existing matches)', {
-                            collection: item.name,
-                            indexName,
-                        });
                         logger.info(`Index ${indexName} already exists with correct options for ${item.name}`);
                         continue;
                     }
 
                     // Index exists with different options - recreate it
-                    console.log('[DBG:INIT] iter: rotating index (options differ)', {
-                        collection: item.name,
-                        indexName,
-                    });
                     logger.warn(
                         `Index ${indexName} exists with different options for ${item.name}. Recreating with correct options.`
                     );
@@ -282,31 +228,12 @@ export class MongoClientManager {
                     await this.rotateIndex(collection, item, indexName);
                 } else {
                     // Index doesn't exist - create it
-                    console.log('[DBG:INIT] iter: creating fresh index', {
-                        collection: item.name,
-                        indexName,
-                        indexKeys: item.indexKeys,
-                        unique: item.unique,
-                    });
-                    const createdName = await collection.createIndex(item.indexKeys, {
-                        unique: item.unique,
-                        name: indexName,
-                    });
-                    console.log('[DBG:INIT] iter: createIndex resolved', {
-                        collection: item.name,
-                        requestedName: indexName,
-                        createdName,
-                    });
+                    await collection.createIndex(item.indexKeys, { unique: item.unique, name: indexName });
+
                     logger.info(`Created index ${indexName} for ${item.name}`);
                 }
             } catch (error) {
                 const mongoError = error as MongoError;
-                console.log('[DBG:INIT] iter: caught error', {
-                    collection: item.name,
-                    indexName,
-                    code: mongoError.code,
-                    message: mongoError.message,
-                });
 
                 // Handle race condition: index was created between our check and create attempt
                 if (mongoError.code === 86) {
@@ -322,7 +249,6 @@ export class MongoClientManager {
             }
         }
 
-        console.log('[DBG:INIT] initializeDb: done', { dbName: db.databaseName });
         logger.info('Collections indexed');
     }
 
@@ -335,34 +261,14 @@ export class MongoClientManager {
      * @param indexName The name of the index to recreate
      */
     private async rotateIndex(collection: Collection, item: CollectionConfig, indexName: string) {
-        console.log('[DBG:INIT] rotateIndex: start', {
-            collection: collection.collectionName,
-            indexName,
-            indexKeys: item.indexKeys,
-            unique: item.unique,
-        });
         try {
             await collection.dropIndex(indexName);
-            console.log('[DBG:INIT] rotateIndex: dropped', {
-                collection: collection.collectionName,
-                indexName,
-            });
         } catch (dropError) {
             // Index might already be dropped or not exist - continue with recreation
-            console.log('[DBG:INIT] rotateIndex: drop skipped', {
-                collection: collection.collectionName,
-                indexName,
-                message: (dropError as Error).message,
-            });
             logger.warn(`Could not drop index ${indexName} (may not exist): ${(dropError as Error).message}`);
         }
 
-        const createdName = await collection.createIndex(item.indexKeys, { unique: item.unique, name: indexName });
-        console.log('[DBG:INIT] rotateIndex: recreated', {
-            collection: collection.collectionName,
-            requestedName: indexName,
-            createdName,
-        });
+        await collection.createIndex(item.indexKeys, { unique: item.unique, name: indexName });
 
         logger.info(`Successfully recreated index ${indexName} for ${collection.collectionName}`);
     }

--- a/backend/src/aop/db/mongo/client/index.ts
+++ b/backend/src/aop/db/mongo/client/index.ts
@@ -180,8 +180,9 @@ export class MongoClientManager {
             try {
                 // Check if index already exists
                 const existingIndexes = await collection.indexes();
+                console.log('existingIndexes', existingIndexes);
                 const existingIndex = existingIndexes.find(idx => idx.name === indexName);
-
+                console.log('existingIndex', existingIndex);
                 if (existingIndex) {
                     const existingKey = existingIndex.key;
                     const configuredKey = item.indexKeys;
@@ -191,9 +192,9 @@ export class MongoClientManager {
                         ([field, order]) => existingKey[field] === order
                     );
                     const hasSameUniqueOption = existingIndex.unique === item.unique;
-                    const indexMatchesConfig = hasSameUniqueOption && hasSameFieldCount && hasSameFieldsAndOrder;
 
-                    if (indexMatchesConfig) {
+                    const areIndexesTheSame = hasSameUniqueOption && hasSameFieldCount && hasSameFieldsAndOrder;
+                    if (areIndexesTheSame) {
                         // Index exists with correct options - no action needed
                         logger.info(`Index ${indexName} already exists with correct options for ${item.name}`);
                         continue;
@@ -204,7 +205,7 @@ export class MongoClientManager {
                         `Index ${indexName} exists with different options for ${item.name}. Recreating with correct options.`
                     );
 
-                    await this.recreateIndex(collection, item, indexName);
+                    await this.rotateIndex(collection, item, indexName);
                 } else {
                     // Index doesn't exist - create it
                     await collection.createIndex(item.indexKeys, { unique: item.unique, name: indexName });
@@ -220,7 +221,7 @@ export class MongoClientManager {
                         `Index conflict detected for ${item.name} during creation. Recreating with correct options.`
                     );
 
-                    await this.recreateIndex(collection, item, indexName);
+                    await this.rotateIndex(collection, item, indexName);
                 } else {
                     // Re-throw unexpected errors
                     throw error;
@@ -239,7 +240,7 @@ export class MongoClientManager {
      * @param item The collection configuration item containing index settings
      * @param indexName The name of the index to recreate
      */
-    private async recreateIndex(collection: Collection, item: CollectionConfig, indexName: string) {
+    private async rotateIndex(collection: Collection, item: CollectionConfig, indexName: string) {
         try {
             await collection.dropIndex(indexName);
         } catch (dropError) {

--- a/backend/src/aop/db/mongo/client/index.ts
+++ b/backend/src/aop/db/mongo/client/index.ts
@@ -52,7 +52,18 @@ export class MongoClientManager {
         }
 
         if (!this.instance && options) {
+            console.log('[DBG:MGR] getInstance: creating new MongoClientManager', {
+                uri: options.uri,
+                dbName: options.dbName,
+            });
             this.instance = new MongoClientManager(options);
+        } else {
+            console.log('[DBG:MGR] getInstance: returning existing instance', {
+                uri: this.instance.uri,
+                dbName: this.instance.dbName,
+                hasClient: !!this.instance.client,
+                hasDb: !!this.instance.db,
+            });
         }
 
         return this.instance;
@@ -74,8 +85,16 @@ export class MongoClientManager {
     async connect(customClient?: MongoClient) {
         // Return existing connection if already established
         if (this.db) {
+            console.log('[DBG:MGR] connect: cache hit, returning existing db', { dbName: this.dbName });
             return this.db;
         }
+
+        console.log('[DBG:MGR] connect: fresh connect starting', {
+            uri: this.uri,
+            dbName: this.dbName,
+            hasCustomClient: !!customClient,
+            hasExistingClient: !!this.client,
+        });
 
         // Use custom client if provided (typically for testing)
         if (customClient) {
@@ -86,14 +105,17 @@ export class MongoClientManager {
         if (!this.client) {
             this.client = new MongoClient(this.uri);
             await this.client.connect();
+            console.log('[DBG:MGR] connect: MongoClient connected', { uri: this.uri });
         }
 
         // Select the target database
         this.db = this.client.db(this.dbName);
+        console.log('[DBG:MGR] connect: db selected', { dbName: this.dbName });
 
         // Initialize database (ping + create indexes)
         await this.initializeDb(this.db);
 
+        console.log('[DBG:MGR] connect: fully initialized, returning db', { dbName: this.dbName });
         return this.db;
     }
 
@@ -105,11 +127,19 @@ export class MongoClientManager {
      * @returns Promise that resolves when disconnection is complete
      */
     async disconnect() {
+        console.log('[DBG:MGR] disconnect: called', {
+            hasClient: !!this.client,
+            hasDb: !!this.db,
+            dbName: this.dbName,
+        });
         if (this.client) {
             await this.client.close();
 
             this.client = null;
             this.db = null;
+            console.log('[DBG:MGR] disconnect: client closed, state cleared');
+        } else {
+            console.log('[DBG:MGR] disconnect: no client to close');
         }
     }
 
@@ -147,29 +177,59 @@ export class MongoClientManager {
      * @throws Error if database ping fails or index operations fail unrecoverably
      */
     private async initializeDb(db: Db) {
+        console.log('[DBG:INIT] initializeDb: start', { dbName: db.databaseName });
+
         // Verify database connectivity
         logger.info('Pinging database');
 
         await db.command({ ping: 1 });
 
+        console.log('[DBG:INIT] initializeDb: ping ok', { dbName: db.databaseName });
         logger.info('Database pinged');
 
         // Create or update indexes for configured collections
         logger.info('Indexing collections');
 
         const collections = Object.values(config.db.collection).filter(item => item.index);
+        console.log(
+            '[DBG:INIT] initializeDb: collections to index',
+            collections.map(c => ({ name: c.name, indexKeys: c.indexKeys, unique: c.unique }))
+        );
 
         for (const item of collections) {
             const indexName = utils.buildIndexName(item.indexKeys);
             const collection = db.collection(item.name);
+
+            console.log('[DBG:INIT] iter: enter', {
+                collection: item.name,
+                indexName,
+                indexKeys: item.indexKeys,
+                unique: item.unique,
+                dropLegacyIndexes: item.dropLegacyIndexes,
+            });
+
+            const indexesBeforeDrop = await collection.indexes();
+            console.log('[DBG:INIT] iter: indexes BEFORE drop-legacy', {
+                collection: item.name,
+                indexes: indexesBeforeDrop,
+            });
 
             // Drop legacy indexes if they exist
             if (item.dropLegacyIndexes.length) {
                 for (const legacyIndexName of item.dropLegacyIndexes) {
                     try {
                         await collection.dropIndex(legacyIndexName);
+                        console.log('[DBG:INIT] iter: dropped legacy', {
+                            collection: item.name,
+                            legacyIndexName,
+                        });
                         logger.info(`Dropped legacy index ${legacyIndexName} for ${item.name}`);
                     } catch (dropError) {
+                        console.log('[DBG:INIT] iter: legacy drop skipped (not found)', {
+                            collection: item.name,
+                            legacyIndexName,
+                            message: (dropError as Error).message,
+                        });
                         logger.warn(
                             `Could not drop legacy index ${legacyIndexName} for ${item.name} (may not exist): ${(dropError as Error).message}`
                         );
@@ -180,6 +240,10 @@ export class MongoClientManager {
             try {
                 // Check if index already exists
                 const existingIndexes = await collection.indexes();
+                console.log('[DBG:INIT] iter: indexes AFTER drop-legacy / BEFORE create', {
+                    collection: item.name,
+                    indexes: existingIndexes,
+                });
                 const existingIndex = existingIndexes.find(idx => idx.name === indexName);
                 if (existingIndex) {
                     const existingKey = existingIndex.key;
@@ -192,13 +256,31 @@ export class MongoClientManager {
                     const hasSameUniqueOption = existingIndex.unique === item.unique;
 
                     const areIndexesTheSame = hasSameUniqueOption && hasSameFieldCount && hasSameFieldsAndOrder;
+                    console.log('[DBG:INIT] iter: existing index found, comparison', {
+                        collection: item.name,
+                        indexName,
+                        existingKey,
+                        configuredKey,
+                        hasSameFieldCount,
+                        hasSameFieldsAndOrder,
+                        hasSameUniqueOption,
+                        areIndexesTheSame,
+                    });
                     if (areIndexesTheSame) {
                         // Index exists with correct options - no action needed
+                        console.log('[DBG:INIT] iter: skip (existing matches)', {
+                            collection: item.name,
+                            indexName,
+                        });
                         logger.info(`Index ${indexName} already exists with correct options for ${item.name}`);
                         continue;
                     }
 
                     // Index exists with different options - recreate it
+                    console.log('[DBG:INIT] iter: rotating index (options differ)', {
+                        collection: item.name,
+                        indexName,
+                    });
                     logger.warn(
                         `Index ${indexName} exists with different options for ${item.name}. Recreating with correct options.`
                     );
@@ -206,13 +288,31 @@ export class MongoClientManager {
                     await this.rotateIndex(collection, item, indexName);
                 } else {
                     // Index doesn't exist - create it
-                    await collection.createIndex(item.indexKeys, { unique: item.unique, name: indexName });
-                    const existingIndexes = await collection.indexes();
-                    console.log('created indexes', existingIndexes);
+                    console.log('[DBG:INIT] iter: creating fresh index', {
+                        collection: item.name,
+                        indexName,
+                        indexKeys: item.indexKeys,
+                        unique: item.unique,
+                    });
+                    const createdName = await collection.createIndex(item.indexKeys, {
+                        unique: item.unique,
+                        name: indexName,
+                    });
+                    console.log('[DBG:INIT] iter: createIndex resolved', {
+                        collection: item.name,
+                        requestedName: indexName,
+                        createdName,
+                    });
                     logger.info(`Created index ${indexName} for ${item.name}`);
                 }
             } catch (error) {
                 const mongoError = error as MongoError;
+                console.log('[DBG:INIT] iter: caught error', {
+                    collection: item.name,
+                    indexName,
+                    code: mongoError.code,
+                    message: mongoError.message,
+                });
 
                 // Handle race condition: index was created between our check and create attempt
                 if (mongoError.code === 86) {
@@ -226,8 +326,15 @@ export class MongoClientManager {
                     throw error;
                 }
             }
+
+            const indexesAfter = await collection.indexes();
+            console.log('[DBG:INIT] iter: indexes AFTER operation', {
+                collection: item.name,
+                indexes: indexesAfter,
+            });
         }
 
+        console.log('[DBG:INIT] initializeDb: done', { dbName: db.databaseName });
         logger.info('Collections indexed');
     }
 
@@ -240,14 +347,34 @@ export class MongoClientManager {
      * @param indexName The name of the index to recreate
      */
     private async rotateIndex(collection: Collection, item: CollectionConfig, indexName: string) {
+        console.log('[DBG:INIT] rotateIndex: start', {
+            collection: collection.collectionName,
+            indexName,
+            indexKeys: item.indexKeys,
+            unique: item.unique,
+        });
         try {
             await collection.dropIndex(indexName);
+            console.log('[DBG:INIT] rotateIndex: dropped', {
+                collection: collection.collectionName,
+                indexName,
+            });
         } catch (dropError) {
             // Index might already be dropped or not exist - continue with recreation
+            console.log('[DBG:INIT] rotateIndex: drop skipped', {
+                collection: collection.collectionName,
+                indexName,
+                message: (dropError as Error).message,
+            });
             logger.warn(`Could not drop index ${indexName} (may not exist): ${(dropError as Error).message}`);
         }
 
-        await collection.createIndex(item.indexKeys, { unique: item.unique, name: indexName });
+        const createdName = await collection.createIndex(item.indexKeys, { unique: item.unique, name: indexName });
+        console.log('[DBG:INIT] rotateIndex: recreated', {
+            collection: collection.collectionName,
+            requestedName: indexName,
+            createdName,
+        });
 
         logger.info(`Successfully recreated index ${indexName} for ${collection.collectionName}`);
     }

--- a/backend/src/aop/db/mongo/client/index.ts
+++ b/backend/src/aop/db/mongo/client/index.ts
@@ -180,9 +180,7 @@ export class MongoClientManager {
             try {
                 // Check if index already exists
                 const existingIndexes = await collection.indexes();
-                console.log('existingIndexes', existingIndexes);
                 const existingIndex = existingIndexes.find(idx => idx.name === indexName);
-                console.log('existingIndex', existingIndex);
                 if (existingIndex) {
                     const existingKey = existingIndex.key;
                     const configuredKey = item.indexKeys;
@@ -209,7 +207,8 @@ export class MongoClientManager {
                 } else {
                     // Index doesn't exist - create it
                     await collection.createIndex(item.indexKeys, { unique: item.unique, name: indexName });
-
+                    const existingIndexes = await collection.indexes();
+                    console.log('created indexes', existingIndexes);
                     logger.info(`Created index ${indexName} for ${item.name}`);
                 }
             } catch (error) {

--- a/backend/src/aop/db/mongo/client/index.ts
+++ b/backend/src/aop/db/mongo/client/index.ts
@@ -208,12 +208,6 @@ export class MongoClientManager {
                 dropLegacyIndexes: item.dropLegacyIndexes,
             });
 
-            const indexesBeforeDrop = await collection.indexes();
-            console.log('[DBG:INIT] iter: indexes BEFORE drop-legacy', {
-                collection: item.name,
-                indexes: indexesBeforeDrop,
-            });
-
             // Drop legacy indexes if they exist
             if (item.dropLegacyIndexes.length) {
                 for (const legacyIndexName of item.dropLegacyIndexes) {
@@ -326,12 +320,6 @@ export class MongoClientManager {
                     throw error;
                 }
             }
-
-            const indexesAfter = await collection.indexes();
-            console.log('[DBG:INIT] iter: indexes AFTER operation', {
-                collection: item.name,
-                indexes: indexesAfter,
-            });
         }
 
         console.log('[DBG:INIT] initializeDb: done', { dbName: db.databaseName });

--- a/backend/src/aop/db/mongo/client/index.ts
+++ b/backend/src/aop/db/mongo/client/index.ts
@@ -4,9 +4,11 @@ import { InternalException } from 'aop/exceptions/errors/system';
 import { logger } from 'aop/logging';
 
 import config from '../config';
+import utils from './utils';
 
 import { ErrorMessage } from 'shared/enums/error-messages';
 
+import type { CollectionConfig } from '../shared/types';
 import type { MongoClientOptions } from './types';
 
 /**
@@ -132,12 +134,13 @@ export class MongoClientManager {
      * 2. **Index Management**: Creates or updates indexes for collections marked in configuration
      *
      * Index management behavior:
-     * - Checks if each required index already exists with correct options (unique, field, order)
+     * - Drops legacy indexes listed in `dropLegacyIndexes` before managing the configured index
+     * - Checks if each required index already exists with correct options (unique, key shape)
      * - If index exists with correct options: skips creation (idempotent)
      * - If index exists with different options: drops and recreates with correct options
      * - If index doesn't exist: creates it with the specified configuration
      *
-     * All indexes use explicit names following MongoDB's pattern: `{field}_{order}` (e.g., `email_1`, `name_1`)
+     * All indexes use explicit names following MongoDB's pattern (e.g. `email_1`, `userId_1_name_1`)
      * to ensure predictable behavior and avoid conflicts.
      *
      * @param db The MongoDB database instance to initialize
@@ -157,8 +160,22 @@ export class MongoClientManager {
         const collections = Object.values(config.db.collection).filter(item => item.index);
 
         for (const item of collections) {
-            const indexName = `${item.targetField}_${item.targetValue}`;
+            const indexName = utils.buildIndexName(item.indexKeys);
             const collection = db.collection(item.name);
+
+            // Drop legacy indexes if they exist
+            if (item.dropLegacyIndexes.length) {
+                for (const legacyIndexName of item.dropLegacyIndexes) {
+                    try {
+                        await collection.dropIndex(legacyIndexName);
+                        logger.info(`Dropped legacy index ${legacyIndexName} for ${item.name}`);
+                    } catch (dropError) {
+                        logger.warn(
+                            `Could not drop legacy index ${legacyIndexName} for ${item.name} (may not exist): ${(dropError as Error).message}`
+                        );
+                    }
+                }
+            }
 
             try {
                 // Check if index already exists
@@ -166,31 +183,33 @@ export class MongoClientManager {
                 const existingIndex = existingIndexes.find(idx => idx.name === indexName);
 
                 if (existingIndex) {
-                    // Index exists - verify options match
-                    const isUnique = existingIndex.unique === true;
+                    const existingKey = existingIndex.key;
+                    const configuredKey = item.indexKeys;
 
-                    if (isUnique === item.unique) {
+                    const hasSameFieldCount = Object.keys(configuredKey).length === Object.keys(existingKey).length;
+                    const hasSameFieldsAndOrder = Object.entries(configuredKey).every(
+                        ([field, order]) => existingKey[field] === order
+                    );
+                    const hasSameUniqueOption = existingIndex.unique === item.unique;
+                    const indexMatchesConfig = hasSameUniqueOption && hasSameFieldCount && hasSameFieldsAndOrder;
+
+                    if (indexMatchesConfig) {
                         // Index exists with correct options - no action needed
-                        logger.info(
-                            `Index ${indexName} already exists with correct options for ${item.name}.${item.targetField}`
-                        );
+                        logger.info(`Index ${indexName} already exists with correct options for ${item.name}`);
                         continue;
                     }
 
                     // Index exists with different options - recreate it
                     logger.warn(
-                        `Index ${indexName} exists with different options for ${item.name}.${item.targetField}. Recreating with correct options.`
+                        `Index ${indexName} exists with different options for ${item.name}. Recreating with correct options.`
                     );
 
                     await this.recreateIndex(collection, item, indexName);
                 } else {
                     // Index doesn't exist - create it
-                    await collection.createIndex(
-                        { [item.targetField]: item.targetValue },
-                        { unique: item.unique, name: indexName }
-                    );
+                    await collection.createIndex(item.indexKeys, { unique: item.unique, name: indexName });
 
-                    logger.info(`Created index ${indexName} for ${item.name}.${item.targetField}`);
+                    logger.info(`Created index ${indexName} for ${item.name}`);
                 }
             } catch (error) {
                 const mongoError = error as MongoError;
@@ -198,7 +217,7 @@ export class MongoClientManager {
                 // Handle race condition: index was created between our check and create attempt
                 if (mongoError.code === 86) {
                     logger.warn(
-                        `Index conflict detected for ${item.name}.${item.targetField} during creation. Recreating with correct options.`
+                        `Index conflict detected for ${item.name} during creation. Recreating with correct options.`
                     );
 
                     await this.recreateIndex(collection, item, indexName);
@@ -220,11 +239,7 @@ export class MongoClientManager {
      * @param item The collection configuration item containing index settings
      * @param indexName The name of the index to recreate
      */
-    private async recreateIndex(
-        collection: Collection,
-        item: { targetField: string; targetValue: number; unique: boolean },
-        indexName: string
-    ) {
+    private async recreateIndex(collection: Collection, item: CollectionConfig, indexName: string) {
         try {
             await collection.dropIndex(indexName);
         } catch (dropError) {
@@ -232,11 +247,8 @@ export class MongoClientManager {
             logger.warn(`Could not drop index ${indexName} (may not exist): ${(dropError as Error).message}`);
         }
 
-        await collection.createIndex(
-            { [item.targetField]: item.targetValue },
-            { unique: item.unique, name: indexName }
-        );
+        await collection.createIndex(item.indexKeys, { unique: item.unique, name: indexName });
 
-        logger.info(`Successfully recreated index ${indexName} for ${collection.collectionName}.${item.targetField}`);
+        logger.info(`Successfully recreated index ${indexName} for ${collection.collectionName}`);
     }
 }

--- a/backend/src/aop/db/mongo/client/utils/index.ts
+++ b/backend/src/aop/db/mongo/client/utils/index.ts
@@ -1,0 +1,16 @@
+import type { IndexKeySpec } from '../../shared/types';
+
+/**
+ * Builds an explicit index name from key spec following MongoDB's pattern (e.g. `email_1`, `userId_1_name_1`).
+ */
+function buildIndexName(indexKeys: IndexKeySpec): string {
+    return Object.entries(indexKeys)
+        .map(([field, order]) => `${field}_${order}`)
+        .join('_');
+}
+
+const utils = {
+    buildIndexName,
+};
+
+export default utils;

--- a/backend/src/aop/db/mongo/config/index.ts
+++ b/backend/src/aop/db/mongo/config/index.ts
@@ -1,5 +1,7 @@
 import config from 'config';
 
+import type { MongoConfig } from '../shared/types';
+
 /**
  * MongoDB configuration object containing database connection details and collection settings.
  * This configuration drives the database initialization, indexing, and repository setup.
@@ -11,29 +13,20 @@ const mongoConfig = {
         collection: {
             users: {
                 name: config.mongoUserCollectionName,
-                // Field to create index on (e.g., 'email')
-                targetField: 'email',
-                // Index sort order: 1 for ascending, -1 for descending
-                targetValue: 1,
-                // Whether the index should enforce uniqueness
+                indexKeys: { email: 1 as const },
                 unique: true,
-                // Whether to create an index for this collection at startup
                 index: true,
+                dropLegacyIndexes: [],
             },
             jobs: {
                 name: config.mongoJobsCollectionName,
-                // Field to create index on (e.g., 'name')
-                // TODO: job.name should be unique per user, not globally.
-                targetField: 'name',
-                // Index sort order: 1 for ascending, -1 for descending
-                targetValue: 1,
-                // Enforce unique job names for clear identification in dashboards
+                indexKeys: { userId: 1 as const, name: 1 as const },
                 unique: true,
-                // Whether to create an index for this collection at startup
                 index: true,
+                dropLegacyIndexes: ['name_1'],
             },
         },
     },
-};
+} satisfies MongoConfig;
 
 export default mongoConfig;

--- a/backend/src/aop/db/mongo/shared/types/index.ts
+++ b/backend/src/aop/db/mongo/shared/types/index.ts
@@ -1,0 +1,31 @@
+/** MongoDB index key specification: field name to sort order (1 ascending, -1 descending). */
+type IndexKeySpec = Record<string, 1 | -1>;
+
+/** Indexed collection settings from mongo config, consumed by MongoClientManager at startup. */
+interface CollectionConfig {
+    name: string;
+    indexKeys: IndexKeySpec;
+    unique: boolean;
+    index: boolean;
+    dropLegacyIndexes: string[];
+}
+
+/** Collections in the MongoDB database. */
+interface Collection {
+    users: CollectionConfig;
+    jobs: CollectionConfig;
+}
+
+/** Collections in the MongoDB database. */
+type Collections = keyof Collection;
+
+/** MongoDB configuration object containing database connection details and collection settings. */
+interface MongoConfig {
+    db: {
+        name: string;
+        uri: string;
+        collection: Record<Collections, CollectionConfig>;
+    };
+}
+
+export type { CollectionConfig, Collection, Collections, MongoConfig, IndexKeySpec };

--- a/backend/src/server/index.ts
+++ b/backend/src/server/index.ts
@@ -18,8 +18,6 @@ import { initializeDatabase } from './server-initialize-db';
 // TODO: (node:25) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
 // TODO: (Use `node --trace-deprecation ...` to show where the warning was created)
 
-// TODO: Fix: job.name should be unique per user, not globally.
-
 const init = async () => {
     const REQ_BODY_LIMIT = '6mb';
     const server = express();

--- a/backend/test/integration/harness.ts
+++ b/backend/test/integration/harness.ts
@@ -11,7 +11,10 @@ import server from 'server';
  * Builds the real Express app (Mongo connect, indexes, job reschedule, middleware, routes).
  */
 const initServer = async (): Promise<Express> => {
-    return server.init();
+    console.log('[DBG:HARNESS] initServer: calling server.init()');
+    const app = await server.init();
+    console.log('[DBG:HARNESS] initServer: server.init() resolved');
+    return app;
 };
 
 /**
@@ -19,6 +22,8 @@ const initServer = async (): Promise<Express> => {
  */
 const deleteCronJobs = async (): Promise<void> => {
     const scheduler = Scheduler.getInstance();
+    const jobIds = scheduler.allJobs.map(j => j.jobId);
+    console.log('[DBG:HARNESS] deleteCronJobs: clearing', { count: jobIds.length, jobIds });
     for (const job of scheduler.allJobs) {
         scheduler.delete(job.jobId);
     }
@@ -32,15 +37,39 @@ const clearCollections = async (): Promise<void> => {
     const db = await manager.connect();
     const collections = await db.collections();
 
+    const beforeSnapshot = await Promise.all(
+        collections.map(async c => ({
+            name: c.collectionName,
+            indexes: await c.indexes(),
+        }))
+    );
+    console.log('[DBG:HARNESS] clearCollections: BEFORE deleteMany', {
+        dbName: db.databaseName,
+        collections: beforeSnapshot,
+    });
+
     await Promise.all(collections.map(collection => collection.deleteMany({})));
+
+    const afterSnapshot = await Promise.all(
+        collections.map(async c => ({
+            name: c.collectionName,
+            indexes: await c.indexes(),
+        }))
+    );
+    console.log('[DBG:HARNESS] clearCollections: AFTER deleteMany', {
+        dbName: db.databaseName,
+        collections: afterSnapshot,
+    });
 };
 
 /**
  * Disconnects from MongoDB.
  */
 const disconnectMongo = async (): Promise<void> => {
+    console.log('[DBG:HARNESS] disconnectMongo: calling manager.disconnect()');
     const manager = MongoClientManager.getInstance();
     await manager.disconnect();
+    console.log('[DBG:HARNESS] disconnectMongo: done');
 };
 
 /**

--- a/backend/test/integration/harness.ts
+++ b/backend/test/integration/harness.ts
@@ -11,10 +11,7 @@ import server from 'server';
  * Builds the real Express app (Mongo connect, indexes, job reschedule, middleware, routes).
  */
 const initServer = async (): Promise<Express> => {
-    console.log('[DBG:HARNESS] initServer: calling server.init()');
-    const app = await server.init();
-    console.log('[DBG:HARNESS] initServer: server.init() resolved');
-    return app;
+    return server.init();
 };
 
 /**
@@ -22,8 +19,6 @@ const initServer = async (): Promise<Express> => {
  */
 const deleteCronJobs = async (): Promise<void> => {
     const scheduler = Scheduler.getInstance();
-    const jobIds = scheduler.allJobs.map(j => j.jobId);
-    console.log('[DBG:HARNESS] deleteCronJobs: clearing', { count: jobIds.length, jobIds });
     for (const job of scheduler.allJobs) {
         scheduler.delete(job.jobId);
     }
@@ -37,39 +32,15 @@ const clearCollections = async (): Promise<void> => {
     const db = await manager.connect();
     const collections = await db.collections();
 
-    const beforeSnapshot = await Promise.all(
-        collections.map(async c => ({
-            name: c.collectionName,
-            indexes: await c.indexes(),
-        }))
-    );
-    console.log('[DBG:HARNESS] clearCollections: BEFORE deleteMany', {
-        dbName: db.databaseName,
-        collections: beforeSnapshot,
-    });
-
     await Promise.all(collections.map(collection => collection.deleteMany({})));
-
-    const afterSnapshot = await Promise.all(
-        collections.map(async c => ({
-            name: c.collectionName,
-            indexes: await c.indexes(),
-        }))
-    );
-    console.log('[DBG:HARNESS] clearCollections: AFTER deleteMany', {
-        dbName: db.databaseName,
-        collections: afterSnapshot,
-    });
 };
 
 /**
  * Disconnects from MongoDB.
  */
 const disconnectMongo = async (): Promise<void> => {
-    console.log('[DBG:HARNESS] disconnectMongo: calling manager.disconnect()');
     const manager = MongoClientManager.getInstance();
     await manager.disconnect();
-    console.log('[DBG:HARNESS] disconnectMongo: done');
 };
 
 /**

--- a/backend/test/integration/jobs-integration.test.ts
+++ b/backend/test/integration/jobs-integration.test.ts
@@ -2,6 +2,8 @@ import { ObjectId } from 'mongodb';
 
 import type { CreateJobInput, UpdateJobInput } from 'modules/jobs/types';
 
+import { MongoClientManager } from 'aop/db/mongo/client';
+import config from 'aop/db/mongo/config';
 import { ErrorCode } from 'aop/exceptions/shared/enums';
 
 import constants from 'shared/constants';
@@ -342,6 +344,12 @@ describe('Integration: jobs HTTP', () => {
             });
 
             it('[JOBS-UNQ-002] returns conflict when the same user creates a duplicate job name', async () => {
+                const instance = MongoClientManager.getInstance();
+                const db = await instance.connect();
+                const collection = db.collection(config.db.collection.jobs.name);
+                const existingIndexes = await collection.indexes();
+                console.log('existingIndexes', existingIndexes);
+
                 const email = 'unq-duplicate-create@example.com';
                 const registerResponse = await getRegisterResponse(agent, email);
                 expect(registerResponse.status).toBe(200);

--- a/backend/test/integration/jobs-integration.test.ts
+++ b/backend/test/integration/jobs-integration.test.ts
@@ -115,19 +115,25 @@ describe('Integration: jobs HTTP', () => {
     let agent: ReturnType<typeof getAgent>;
 
     beforeAll(async () => {
+        console.log('[DBG:JOBS-FILE] beforeAll: start');
         app = await initServer();
         agent = getAgent(app);
+        console.log('[DBG:JOBS-FILE] beforeAll: end (initServer awaited)');
     });
 
     beforeEach(async () => {
+        console.log('[DBG:JOBS-FILE] beforeEach: start');
         await deleteCronJobs();
         await clearCollections();
+        console.log('[DBG:JOBS-FILE] beforeEach: end');
     });
 
     afterAll(async () => {
+        console.log('[DBG:JOBS-FILE] afterAll: start');
         await deleteCronJobs();
         await clearCollections();
         await disconnectMongo();
+        console.log('[DBG:JOBS-FILE] afterAll: end');
     });
 
     describe(`GET ${constants.routes.jobs.getAll} — unauthenticated access`, () => {
@@ -346,19 +352,64 @@ describe('Integration: jobs HTTP', () => {
             it('[JOBS-UNQ-002] returns conflict when the same user creates a duplicate job name', async () => {
                 const instance = MongoClientManager.getInstance();
                 const db = await instance.connect();
-                const collection = db.collection(config.db.collection.jobs.name);
-                const existingIndexes = await collection.indexes();
-                console.log('existingIndexes', existingIndexes);
+                const jobsCollectionName = config.db.collection.jobs.name;
+                const collection = db.collection(jobsCollectionName);
+
+                console.log('[DBG:TEST] UNQ-002: test start', {
+                    dbName: db.databaseName,
+                    jobsCollectionName,
+                });
+
+                const indexesAtStart = await collection.indexes();
+                console.log('[DBG:TEST] UNQ-002: jobs indexes at test start', {
+                    indexes: indexesAtStart,
+                });
 
                 const email = 'unq-duplicate-create@example.com';
                 const registerResponse = await getRegisterResponse(agent, email);
                 expect(registerResponse.status).toBe(200);
                 const token = registerResponse.body.data as string;
 
+                // Decode the access token (no verify) to confirm the userId both requests will send.
+                const payloadSegment = token.split('.')[1];
+                let decodedUserId: string | undefined;
+                try {
+                    decodedUserId = JSON.parse(Buffer.from(payloadSegment, 'base64url').toString('utf8')).id as
+                        | string
+                        | undefined;
+                } catch (e) {
+                    console.log('[DBG:TEST] UNQ-002: failed to decode token payload', {
+                        message: (e as Error).message,
+                    });
+                }
+                console.log('[DBG:TEST] UNQ-002: registered, decoded userId', { decodedUserId });
+
+                const indexesBeforeFirstPost = await collection.indexes();
+                console.log('[DBG:TEST] UNQ-002: indexes BEFORE first POST', {
+                    indexes: indexesBeforeFirstPost,
+                });
+
                 const first = await agent
                     .post(constants.routes.jobs.create)
                     .set('Authorization', `Bearer ${token}`)
                     .send(buildJobWithoutSchedulePayload('Duplicate create'));
+
+                console.log('[DBG:TEST] UNQ-002: first POST result', {
+                    status: first.status,
+                    body: first.body,
+                });
+
+                const docsAfterFirst = await collection.find({}).toArray();
+                const indexesAfterFirstPost = await collection.indexes();
+                console.log('[DBG:TEST] UNQ-002: state AFTER first POST', {
+                    docsCount: docsAfterFirst.length,
+                    docs: docsAfterFirst.map(d => ({
+                        _id: d._id?.toString?.(),
+                        userId: (d as { userId?: unknown }).userId,
+                        name: (d as { name?: unknown }).name,
+                    })),
+                    indexes: indexesAfterFirstPost,
+                });
 
                 expect(first.status).toBe(201);
 
@@ -366,6 +417,23 @@ describe('Integration: jobs HTTP', () => {
                     .post(constants.routes.jobs.create)
                     .set('Authorization', `Bearer ${token}`)
                     .send(buildJobWithoutSchedulePayload('Duplicate create'));
+
+                console.log('[DBG:TEST] UNQ-002: second POST result', {
+                    status: second.status,
+                    body: second.body,
+                });
+
+                const docsAfterSecond = await collection.find({}).toArray();
+                const indexesAfterSecondPost = await collection.indexes();
+                console.log('[DBG:TEST] UNQ-002: state AFTER second POST', {
+                    docsCount: docsAfterSecond.length,
+                    docs: docsAfterSecond.map(d => ({
+                        _id: d._id?.toString?.(),
+                        userId: (d as { userId?: unknown }).userId,
+                        name: (d as { name?: unknown }).name,
+                    })),
+                    indexes: indexesAfterSecondPost,
+                });
 
                 expect(second.status).toBe(409);
                 expect(second.body.success).toBe(false);

--- a/backend/test/integration/jobs-integration.test.ts
+++ b/backend/test/integration/jobs-integration.test.ts
@@ -107,8 +107,6 @@ function buildUpdateJobPayload(
  * Each `describe` names the endpoint (`METHOD path`); scenario detail lives in `it` titles and IDs.
  *
  * Requirement IDs: docs/requirements/jobs-http-contract.md
- *
- * @todo – Add a test that validates that job names are unique per user, after fixing the global unique index issue.
  */
 describe('Integration: jobs HTTP', () => {
     let app: Express;
@@ -313,6 +311,58 @@ describe('Integration: jobs HTTP', () => {
             expect(typeof res.body.data.schedule.nextRun).toBe('string');
             const { lastRun } = res.body.data.schedule;
             expect(lastRun === null || typeof lastRun === 'string').toBe(true);
+        });
+
+        describe.sequential('job name uniqueness', () => {
+            const sharedName = 'Shared job name';
+
+            it('[JOBS-UNQ-001] allows different users to create jobs with the same name', async () => {
+                const regA = await getRegisterResponse(agent, 'unq-user-a@example.com');
+                expect(regA.status).toBe(200);
+
+                const regB = await getRegisterResponse(agent, 'unq-user-b@example.com');
+                expect(regB.status).toBe(200);
+
+                const createA = await agent
+                    .post(constants.routes.jobs.create)
+                    .set('Authorization', `Bearer ${regA.body.data}`)
+                    .send(buildJobWithoutSchedulePayload(sharedName));
+
+                expect(createA.status).toBe(201);
+                expect(createA.body.data.name).toBe(sharedName);
+
+                const createB = await agent
+                    .post(constants.routes.jobs.create)
+                    .set('Authorization', `Bearer ${regB.body.data}`)
+                    .send(buildJobWithoutSchedulePayload(sharedName));
+
+                expect(createB.status).toBe(201);
+                expect(createB.body.data.name).toBe(sharedName);
+                expect(createB.body.data.id).not.toBe(createA.body.data.id);
+            });
+
+            it('[JOBS-UNQ-002] returns conflict when the same user creates a duplicate job name', async () => {
+                const email = 'unq-duplicate-create@example.com';
+                const registerResponse = await getRegisterResponse(agent, email);
+                expect(registerResponse.status).toBe(200);
+                const token = registerResponse.body.data as string;
+
+                const first = await agent
+                    .post(constants.routes.jobs.create)
+                    .set('Authorization', `Bearer ${token}`)
+                    .send(buildJobWithoutSchedulePayload('Duplicate create'));
+
+                expect(first.status).toBe(201);
+
+                const second = await agent
+                    .post(constants.routes.jobs.create)
+                    .set('Authorization', `Bearer ${token}`)
+                    .send(buildJobWithoutSchedulePayload('Duplicate create'));
+
+                expect(second.status).toBe(409);
+                expect(second.body.success).toBe(false);
+                expect(second.body.code).toBe(ErrorCode.CONFLICT_ERROR);
+            });
         });
 
         it('[JOBS-SCH-001] rejects a schedule whose start date is not in the future', async () => {
@@ -611,6 +661,37 @@ describe('Integration: jobs HTTP', () => {
 
             expect(getRes.status).toBe(200);
             expect(getRes.body.data.name).toBe('After PUT');
+        });
+
+        it('[JOBS-UNQ-003] returns conflict when updating a job name to another owned job name', async () => {
+            const registerResponse = await getRegisterResponse(agent, 'unq-update@example.com');
+            expect(registerResponse.status).toBe(200);
+            const token = registerResponse.body.data as string;
+
+            const firstJob = await agent
+                .post(constants.routes.jobs.create)
+                .set('Authorization', `Bearer ${token}`)
+                .send(buildJobWithSchedulePayload('First job'));
+
+            expect(firstJob.status).toBe(201);
+
+            const secondJob = await agent
+                .post(constants.routes.jobs.create)
+                .set('Authorization', `Bearer ${token}`)
+                .send(buildJobWithSchedulePayload('Second job'));
+
+            expect(secondJob.status).toBe(201);
+
+            const payload = buildUpdateJobPayload(secondJob.body.data, { name: 'First job' });
+
+            const putRes = await agent
+                .put(buildJobUrl(constants.routes.jobs.update, secondJob.body.data.id))
+                .set('Authorization', `Bearer ${token}`)
+                .send(payload);
+
+            expect(putRes.status).toBe(409);
+            expect(putRes.body.success).toBe(false);
+            expect(putRes.body.code).toBe(ErrorCode.CONFLICT_ERROR);
         });
 
         it('[JOBS-UPD-002] clears schedule when schedule is set to null', async () => {

--- a/backend/test/integration/jobs-integration.test.ts
+++ b/backend/test/integration/jobs-integration.test.ts
@@ -2,8 +2,6 @@ import { ObjectId } from 'mongodb';
 
 import type { CreateJobInput, UpdateJobInput } from 'modules/jobs/types';
 
-import { MongoClientManager } from 'aop/db/mongo/client';
-import config from 'aop/db/mongo/config';
 import { ErrorCode } from 'aop/exceptions/shared/enums';
 
 import constants from 'shared/constants';
@@ -115,25 +113,19 @@ describe('Integration: jobs HTTP', () => {
     let agent: ReturnType<typeof getAgent>;
 
     beforeAll(async () => {
-        console.log('[DBG:JOBS-FILE] beforeAll: start');
         app = await initServer();
         agent = getAgent(app);
-        console.log('[DBG:JOBS-FILE] beforeAll: end (initServer awaited)');
     });
 
     beforeEach(async () => {
-        console.log('[DBG:JOBS-FILE] beforeEach: start');
         await deleteCronJobs();
         await clearCollections();
-        console.log('[DBG:JOBS-FILE] beforeEach: end');
     });
 
     afterAll(async () => {
-        console.log('[DBG:JOBS-FILE] afterAll: start');
         await deleteCronJobs();
         await clearCollections();
         await disconnectMongo();
-        console.log('[DBG:JOBS-FILE] afterAll: end');
     });
 
     describe(`GET ${constants.routes.jobs.getAll} — unauthenticated access`, () => {
@@ -350,66 +342,15 @@ describe('Integration: jobs HTTP', () => {
             });
 
             it('[JOBS-UNQ-002] returns conflict when the same user creates a duplicate job name', async () => {
-                const instance = MongoClientManager.getInstance();
-                const db = await instance.connect();
-                const jobsCollectionName = config.db.collection.jobs.name;
-                const collection = db.collection(jobsCollectionName);
-
-                console.log('[DBG:TEST] UNQ-002: test start', {
-                    dbName: db.databaseName,
-                    jobsCollectionName,
-                });
-
-                const indexesAtStart = await collection.indexes();
-                console.log('[DBG:TEST] UNQ-002: jobs indexes at test start', {
-                    indexes: indexesAtStart,
-                });
-
                 const email = 'unq-duplicate-create@example.com';
                 const registerResponse = await getRegisterResponse(agent, email);
                 expect(registerResponse.status).toBe(200);
                 const token = registerResponse.body.data as string;
 
-                // Decode the access token (no verify) to confirm the userId both requests will send.
-                const payloadSegment = token.split('.')[1];
-                let decodedUserId: string | undefined;
-                try {
-                    decodedUserId = JSON.parse(Buffer.from(payloadSegment, 'base64url').toString('utf8')).id as
-                        | string
-                        | undefined;
-                } catch (e) {
-                    console.log('[DBG:TEST] UNQ-002: failed to decode token payload', {
-                        message: (e as Error).message,
-                    });
-                }
-                console.log('[DBG:TEST] UNQ-002: registered, decoded userId', { decodedUserId });
-
-                const indexesBeforeFirstPost = await collection.indexes();
-                console.log('[DBG:TEST] UNQ-002: indexes BEFORE first POST', {
-                    indexes: indexesBeforeFirstPost,
-                });
-
                 const first = await agent
                     .post(constants.routes.jobs.create)
                     .set('Authorization', `Bearer ${token}`)
                     .send(buildJobWithoutSchedulePayload('Duplicate create'));
-
-                console.log('[DBG:TEST] UNQ-002: first POST result', {
-                    status: first.status,
-                    body: first.body,
-                });
-
-                const docsAfterFirst = await collection.find({}).toArray();
-                const indexesAfterFirstPost = await collection.indexes();
-                console.log('[DBG:TEST] UNQ-002: state AFTER first POST', {
-                    docsCount: docsAfterFirst.length,
-                    docs: docsAfterFirst.map(d => ({
-                        _id: d._id?.toString?.(),
-                        userId: (d as { userId?: unknown }).userId,
-                        name: (d as { name?: unknown }).name,
-                    })),
-                    indexes: indexesAfterFirstPost,
-                });
 
                 expect(first.status).toBe(201);
 
@@ -417,23 +358,6 @@ describe('Integration: jobs HTTP', () => {
                     .post(constants.routes.jobs.create)
                     .set('Authorization', `Bearer ${token}`)
                     .send(buildJobWithoutSchedulePayload('Duplicate create'));
-
-                console.log('[DBG:TEST] UNQ-002: second POST result', {
-                    status: second.status,
-                    body: second.body,
-                });
-
-                const docsAfterSecond = await collection.find({}).toArray();
-                const indexesAfterSecondPost = await collection.indexes();
-                console.log('[DBG:TEST] UNQ-002: state AFTER second POST', {
-                    docsCount: docsAfterSecond.length,
-                    docs: docsAfterSecond.map(d => ({
-                        _id: d._id?.toString?.(),
-                        userId: (d as { userId?: unknown }).userId,
-                        name: (d as { name?: unknown }).name,
-                    })),
-                    indexes: indexesAfterSecondPost,
-                });
 
                 expect(second.status).toBe(409);
                 expect(second.body.success).toBe(false);

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -7,10 +7,5 @@
         "types": [],
         "skipLibCheck": true
     },
-    "exclude": [
-        "**/*.test.ts",
-        "test/**/*",
-        "vitest.config.mjs",
-        "vitest.integration.config.mjs"
-    ]
+    "exclude": ["**/*.test.ts", "test/**/*", "vitest.config.mjs", "vitest.integration.config.mjs"]
 }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -55,6 +55,7 @@ services:
             test: >
                 mongosh -u ${MONGO_ROOT_USERNAME} -p ${MONGO_ROOT_PASSWORD} --authenticationDatabase admin --eval "try { rs.status().ok } catch (e) { rs.initiate({ _id: 'rs0', members: [{ _id: 0, host: 'mongo:27017' }] }).ok }"
 
+
             start_period: 120s
             start_interval: 10s
             interval: 7200s

--- a/docs/requirements/jobs-http-contract.md
+++ b/docs/requirements/jobs-http-contract.md
@@ -64,6 +64,13 @@ Jobs are **owned** by the user identified by the bearer token. Another user MUST
 | **JOBS-CRT-001** | Creating a job **without** a schedule (**`schedule: null`**) succeeds with **201**, **`success: true`**, **`data.name`** and **`data.id`** set, **`data.schedule`** **null**, tools persisted with stable identifiers (**e.g. `toolId`, nested `targetId`** where applicable). |
 | **JOBS-CRT-002** | Creating a **scheduled** job succeeds with **201**, **`success: true`**, non-null **`schedule`** with expected **`type`**, **`startDate`**, string **`nextRun`**, and **`lastRun`** either **`null`** or an ISO string. |
 
+### Job name uniqueness (create)
+
+| ID               | Business rule |
+|------------------|----------------|
+| **JOBS-UNQ-001** | Different users MAY create jobs with the **same** **`name`**; each receives **201** and distinct **`data.id`** values. |
+| **JOBS-UNQ-002** | The **same** user MUST NOT create two jobs with the **same** **`name`**; the second attempt returns **409**, **`success: false`**, **`CONFLICT_ERROR`**. |
+
 ### Schedule validation (create)
 
 | ID               | Business rule |
@@ -91,6 +98,7 @@ Jobs are **owned** by the user identified by the bearer token. Another user MUST
 | **JOBS-UPD-003** | **`schedule: null`** combined with **`runJob: true`** is accepted (**200**); **`schedule`** remains **null** in the response data. |
 | **JOBS-UPD-004** | While the job’s execution delegate is **running**, an update may be rejected with **422**, **`success: false`**, **`BUSINESS_LOGIC_ERROR`** (timing-sensitive; the integration test polls until this outcome or times out). |
 | **JOBS-UPD-005** | **PUT** for a **non-existent** id MUST yield **404**, **`success: false`**, **`NOT_FOUND_ERROR`**. |
+| **JOBS-UNQ-003** | Owner MUST NOT rename a job to the **`name`** of **another job they own**; **409**, **`success: false`**, **`CONFLICT_ERROR`**. |
 
 ---
 
@@ -125,6 +133,7 @@ Primary verification: **`backend/test/integration/jobs/jobs-integration.test.ts`
 | **JOBS-GET-002** | `[JOBS-GET-002]` |
 | **JOBS-CRT-001** | `[JOBS-CRT-001]` |
 | **JOBS-CRT-002** | `[JOBS-CRT-002]` |
+| **JOBS-UNQ-001**, **JOBS-UNQ-002** | `[JOBS-UNQ-001]`, `[JOBS-UNQ-002]` |
 | **JOBS-SCH-001** | `[JOBS-SCH-001]` |
 | **JOBS-SCH-002** | `[JOBS-SCH-002]` |
 | **JOBS-SCH-003** | `[JOBS-SCH-003]` |
@@ -133,6 +142,7 @@ Primary verification: **`backend/test/integration/jobs/jobs-integration.test.ts`
 | **JOBS-TLR-003** | `[JOBS-TLR-003]` — subject + body scenarios |
 | **JOBS-ISO-002** | `[JOBS-ISO-002]` |
 | **JOBS-UPD-001** … **JOBS-UPD-005** | matching `[JOBS-UPD-00x]` titles |
+| **JOBS-UNQ-003** | `[JOBS-UNQ-003]` |
 | **JOBS-ISO-003** | `[JOBS-ISO-003]` |
 | **JOBS-DEL-001**, **JOBS-DEL-002** | `[JOBS-DEL-001]`, `[JOBS-DEL-002]` |
 | **JOBS-SSE-001** | `[JOBS-SSE-001]` |

--- a/frontend/src/components/pages/authentication/Authentication.tsx
+++ b/frontend/src/components/pages/authentication/Authentication.tsx
@@ -40,8 +40,7 @@ const Authentication = () => {
     const navigate = useNavigate();
 
     // Flags
-    const isRegisterActive =
-        config.features.registrationEnabled && location.pathname === config.routes.register;
+    const isRegisterActive = config.features.registrationEnabled && location.pathname === config.routes.register;
 
     /**
      * Sets the input field changes in the state.

--- a/frontend/src/components/ui-app/tabs/Tabs.tsx
+++ b/frontend/src/components/ui-app/tabs/Tabs.tsx
@@ -9,7 +9,7 @@ const Tabs = ({ tabs, tabContents }: TabsProps) => {
         <TabsPrimitive defaultValue={tabs[0].value}>
             <TabsList variant="line">
                 {tabs.map(tab => (
-                    <TabsTrigger key={tab.value} value={tab.value} >
+                    <TabsTrigger key={tab.value} value={tab.value}>
                         <Text size="xs" appearance="foreground">
                             {tab.label}
                         </Text>


### PR DESCRIPTION
fix: enforce per-user job name uniqueness via compound index

Problem
The jobs collection had a global unique index on name only, which prevented two different users from creating jobs with the same name — a multi-tenant bug.

Changes
fix(backend): add compound index

Replaced single-field targetField/targetValue index config with indexKeys (supports compound keys) and a required dropLegacyIndexes list
New shared types IndexKeySpec / CollectionIndexConfig in aop/db/mongo/shared/types/
New client/utils/ with buildIndexName — shared by MongoClientManager and the unit test, removing duplication
MongoClientManager now drops listed legacy indexes at startup and validates both key shape and unique option before skipping index recreation
jobs index changed from { name: 1 } → { userId: 1, name: 1 } unique; drops name_1 on first boot
users index { email: 1 } unchanged
chore(backend): update docs

docs/requirements/jobs-http-contract.md — new job name uniqueness section (JOBS-UNQ-001/002/003)
.agents/rules/database.mdc — unique constraints section updated
.agents/skills/database-query-patterns/SKILL.md — edge case note added
chore(global): housekeeping

Integration tests: JOBS-UNQ-001 (cross-user same name → both 201), JOBS-UNQ-002 (same user duplicate create → 409), JOBS-UNQ-003 (rename to existing owned name → 409); stale @todo removed
server/index.ts: stale TODO removed
tsconfig.build.json, docker-compose.prod.yml, minor frontend tweaks
Notes

No data migration required — existing data is compatible with the compound index, since the old global index already prevented cross-user name collisions.