### PR TITLE
chore(global): add  workflow fix

### DIFF
--- a/.github/scripts/start-e2e-backend.sh
+++ b/.github/scripts/start-e2e-backend.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Start the E2E backend and block until /api/docs/openapi responds.
+# Uses nohup + disown so the process survives this step and keeps running for Playwright.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_FILE="${ROOT_DIR}/backend-e2e.log"
+PID_FILE="${ROOT_DIR}/backend-e2e.pid"
+HEALTH_URL="http://localhost:1000/api/docs/openapi"
+MAX_ATTEMPTS=60
+SLEEP_SECONDS=2
+
+: > "${LOG_FILE}"
+
+cd "${ROOT_DIR}/backend"
+nohup npm run start:e2e >> "${LOG_FILE}" 2>&1 &
+echo $! > "${PID_FILE}"
+disown
+
+echo "Backend starting (pid $(cat "${PID_FILE}")), log: ${LOG_FILE}"
+
+for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
+    if curl -sf "${HEALTH_URL}" > /dev/null; then
+        echo "Backend ready (attempt ${attempt}/${MAX_ATTEMPTS})"
+        exit 0
+    fi
+    sleep "${SLEEP_SECONDS}"
+done
+
+echo "Backend did not become ready within $((MAX_ATTEMPTS * SLEEP_SECONDS))s"
+echo "--- ${LOG_FILE} ---"
+cat "${LOG_FILE}" || true
+exit 1

--- a/.github/scripts/stop-e2e-backend.sh
+++ b/.github/scripts/stop-e2e-backend.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Stop the E2E backend started by start-e2e-backend.sh.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PID_FILE="${ROOT_DIR}/backend-e2e.pid"
+
+if [[ ! -f "${PID_FILE}" ]]; then
+    exit 0
+fi
+
+pid="$(cat "${PID_FILE}")"
+if kill -0 "${pid}" 2>/dev/null; then
+    kill "${pid}" 2>/dev/null || true
+    # ts-node-dev spawns a child; stop the process group if still listening.
+    if lsof -ti:1000 >/dev/null 2>&1; then
+        lsof -ti:1000 | xargs kill -9 2>/dev/null || true
+    fi
+fi
+
+rm -f "${PID_FILE}"

--- a/.github/workflows/reusable-e2e-tests.yml
+++ b/.github/workflows/reusable-e2e-tests.yml
@@ -34,22 +34,8 @@ jobs:
               run: npm ci
               working-directory: backend
 
-            - name: Start backend for E2E
-              working-directory: backend
-              run: npm run start:e2e > ../backend-e2e.log 2>&1 &
-
-            - name: Wait for backend health
-              run: |
-                  for i in $(seq 1 60); do
-                      if curl -sf http://localhost:1000/api/docs/openapi; then
-                          exit 0
-                      fi
-                      sleep 2
-                  done
-                  echo "Backend did not become ready within 120s"
-                  echo "--- backend-e2e.log ---"
-                  cat backend-e2e.log || true
-                  exit 1
+            - name: Start backend and wait for health
+              run: bash .github/scripts/start-e2e-backend.sh
 
             - name: Install Playwright browsers
               run: npx playwright install --with-deps chromium firefox webkit
@@ -58,6 +44,10 @@ jobs:
               run: npm run test:e2e
               env:
                   CI: true
+
+            - name: Stop backend
+              if: always()
+              run: bash .github/scripts/stop-e2e-backend.sh
 
             - name: Upload Playwright report
               if: success() || failure()

--- a/docs/guides/e2e-testing.md
+++ b/docs/guides/e2e-testing.md
@@ -180,11 +180,10 @@ The workflow:
 
 1. Starts MongoDB via Docker Compose (single-node replica set)
 2. Installs root, frontend, and backend dependencies
-3. Starts the backend with `backend/.env.e2e.test` (`npm run start:e2e`)
-4. Waits for the OpenAPI endpoint on `:1000`
-5. Installs Playwright browsers with `--with-deps`
-6. Runs `npm run test:e2e` with `CI=true` — smoke + auth must pass
-7. Uploads HTML report, test artifacts, and backend log on failure
+3. Starts the backend with `npm run start:e2e` and waits for OpenAPI on `:1000` (see [`.github/scripts/start-e2e-backend.sh`](../../.github/scripts/start-e2e-backend.sh) — `nohup`/`disown` keeps the server alive for Playwright)
+4. Installs Playwright browsers with `--with-deps`
+5. Runs `npm run test:e2e` with `CI=true` — smoke + auth must pass
+6. Stops the backend and uploads HTML report, test artifacts, and backend log on failure
 
 Push and PR workflows intentionally skip E2E for speed — see [`docs/requirements/ci-cd.md`](../requirements/ci-cd.md).
 


### PR DESCRIPTION
Summary
Fixes the main-branch E2E workflow failing at “Wait for backend health” after merge.

Root cause: Backend was started in one GitHub Actions step and health-checked in the next. The background process was killed when the first step finished, so the API never became ready within 120s and deploy was blocked.

Fix: Extract backend startup into .github/scripts/start-e2e-backend.sh — start with nohup/disown, poll OpenAPI in the same step, fail fast with logs after 120s. Add stop-e2e-backend.sh for cleanup after E2E runs.