### PR TITLE
fix jobs scraper pipeline issues

### DIFF
--- a/backend/src/aop/delegator/tools/scraper/targets/jobs-ch/README.md
+++ b/backend/src/aop/delegator/tools/scraper/targets/jobs-ch/README.md
@@ -1,0 +1,91 @@
+# jobs.ch scraper
+
+## Overview
+
+jobs.ch is an SPA: search results are loaded from a JSON API, not from static HTML alone. This target uses that API to discover vacancies, then Playwright to scrape each detail page.
+
+```
+keywords → semantic search API (paginated) → detail URLs → Playwright detail scrape → listings
+```
+
+## Current approach
+
+1. **Discover** — `GET https://job-search-api.jobs.ch/search/semantic?query={keywords}&rows=20&page={N}` via `page.request`, with `Origin` / `Referer` headers matching www.jobs.ch.
+2. **Map IDs** — each `documents[].id` becomes `https://www.jobs.ch/en/vacancies/detail/{id}`.
+3. **Scrape** — one browser tab visits each detail URL; title, description, and metadata are read from the DOM (`constants/index.ts` selectors).
+
+`maxPages` limits how many API pages to fetch. `0` means fetch until `currentPage >= numPages` or a page returns no documents.
+
+Implementation: [`index.ts`](index.ts). Types: [`types/index.ts`](types/index.ts).
+
+---
+
+## Previous approach (DOM listing pagination)
+
+The scraper loaded listing pages directly:
+
+```
+https://www.jobs.ch/en/vacancies/?term={keywords}&page={N}
+```
+
+For each page it waited for `[aria-label="Job list"]`, collected `[data-cy="job-link"]` hrefs, and stopped when jobs.ch dropped the `page=` query param from the URL (no more pages in that session).
+
+Detail scraping was identical to today.
+
+---
+
+## Why the previous approach failed
+
+The loop logic was correct for the data it received. The problem was **which data headless received**.
+
+### Manual browser vs headless Playwright
+
+| | Manual browser | Headless Playwright (old) |
+| --- | --- | --- |
+| Listing source | `/search/semantic` JSON | SSR HTML + `?page=N` navigation |
+| Example `?term=react` | ~204 hits, 11 API pages | ~100 hits, ~6 DOM pages |
+| `/search/semantic` called? | Yes — drives the job list | **No** |
+| Other API traffic | — | `/aggregations` only (filter facets, not listings) |
+
+In a real browser, JavaScript hydrates the search UI and fetches `/search/semantic` with `totalHits`, `numPages`, and `documents`. Pagination follows that API.
+
+In headless Playwright, full `page.goto()` navigations to listing URLs did **not** trigger `/search/semantic`. Observed behaviour:
+
+- **Page 1** — no jobs.ch API calls; ~20 links from SSR HTML embedded in the initial response.
+- **Pages 2–6** — only `/aggregations?query=…`; ~20 DOM links per page (page 6 had 1).
+- **Page 7** — URL lost `page=` → url-break stop (correct signal for *that* session, but the session only ever had ~6 pages of data).
+
+So the scraper walked every page headless was given (~100 jobs) while the site’s canonical source had ~204.
+
+### Root cause
+
+**Data-source mismatch.** Manual browsing lists jobs via the semantic search API; headless DOM pagination only saw a truncated SSR/partial listing path that never exposed the full catalog.
+
+This was not caused by:
+
+- **Dedupe** — one duplicate across all pages (`setSkipped=1`).
+- **URL prefix filtering** — no links dropped (`prefixFiltered=0`).
+- **Premature url-break** — six full listing pages before stop on page 7.
+- **Caching** — fresh `chromium.launch()` and server restart each run.
+- **Misleading UI counts** — manual verification confirmed more than 100 real listings exist.
+
+---
+
+## Why the API approach works
+
+`/search/semantic` is the same endpoint the website uses for full result sets. It returns structured pagination (`numPages`, `totalHits`, `documents`) independent of whether headless renders the listing UI.
+
+- No auth required — standard `Origin` / `Referer` / `Accept: application/json` headers suffice.
+- Requests use Playwright `page.request` so listing discovery and detail navigation share one browser context.
+- Detail pages still use DOM scraping — only **discovery** moved off listing-page HTML.
+
+---
+
+## File layout
+
+| File | Role |
+| --- | --- |
+| `index.ts` | API pagination, detail navigation, extraction |
+| `constants/index.ts` | API URLs, detail prefix, DOM selectors |
+| `types/index.ts` | `SemanticSearchResponse` shape |
+| `jobs-ch.test.ts` | Unit tests (API mocked via `page.request.get`) |

--- a/backend/src/aop/delegator/tools/scraper/targets/jobs-ch/constants/index.ts
+++ b/backend/src/aop/delegator/tools/scraper/targets/jobs-ch/constants/index.ts
@@ -27,8 +27,10 @@ const constants = {
         },
     },
     configuration: {
-        baseUrl: 'https://www.jobs.ch/en/vacancies/',
         detailUrlPrefix: 'https://www.jobs.ch/en/vacancies/detail/',
+        semanticSearchApiUrl: 'https://job-search-api.jobs.ch/search/semantic',
+        semanticSearchRows: 20,
+        siteOrigin: 'https://www.jobs.ch',
     },
 } as const;
 

--- a/backend/src/aop/delegator/tools/scraper/targets/jobs-ch/index.ts
+++ b/backend/src/aop/delegator/tools/scraper/targets/jobs-ch/index.ts
@@ -9,6 +9,7 @@ import type {
     ScraperTarget,
     ScraperTargetConfig,
 } from '../../types';
+import type { SemanticSearchResponse } from './types';
 import type { Page } from 'playwright';
 import type { ExecutionScraperToolTargetListing } from 'shared/types/jobs/tools/execution/types-execution-scraper-tool';
 
@@ -17,14 +18,43 @@ import { chromium } from 'playwright';
 import { retryWithFixedInterval } from 'utils/async/utils-async-retry';
 
 /**
- * Build a search URL for jobs.ch with keyword and pagination params.
+ * Fetch one page of vacancy IDs from the jobs.ch semantic search API.
  */
-function buildSearchUrl(keywords: string[], pageIndex: number): string {
+async function fetchSemanticSearchPage(
+    page: Page,
+    query: string,
+    pageIndex: number,
+    scraperTargetConfig: ScraperTargetConfig
+): Promise<SemanticSearchResponse> {
     const params = new URLSearchParams({
-        term: keywords.join(' '),
+        query,
+        rows: constants.configuration.semanticSearchRows.toString(),
         page: pageIndex.toString(),
     });
-    return `${constants.configuration.baseUrl}?${params.toString()}`;
+    const url = `${constants.configuration.semanticSearchApiUrl}?${params.toString()}`;
+
+    return retryWithFixedInterval(
+        async () => {
+            const response = await page.request.get(url, {
+                headers: {
+                    Accept: 'application/json',
+                    Origin: constants.configuration.siteOrigin,
+                    Referer: `${constants.configuration.siteOrigin}/`,
+                },
+            });
+
+            if (!response.ok()) {
+                throw new Error(`Semantic search request failed with status ${response.status()}`);
+            }
+
+            return response.json() as Promise<SemanticSearchResponse>;
+        },
+        {
+            maxAttempts: scraperTargetConfig.totalAttempts,
+            delayMs: scraperTargetConfig.retryDelayMs,
+            operationName: 'fetch semantic search page',
+        }
+    );
 }
 
 /**
@@ -246,8 +276,7 @@ async function scrapeDetailListing(page: Page, url: string): Promise<ExecutionSc
 /**
  * jobs.ch target.
  *
- * Strategy: walk listing URLs by pagination, collect vacancy detail URLs, then scrape
- * each detail page sequentially on one tab.
+ * Strategy: paginate the semantic search API for vacancy IDs, then scrape each detail page sequentially.
  */
 const jobsChTarget: ScraperTarget = {
     async run(scraperTargetConfig: ScraperTargetConfig): Promise<ExecutionScraperToolTargetListing[]> {
@@ -255,91 +284,27 @@ const jobsChTarget: ScraperTarget = {
         const page = await browser.newPage();
 
         try {
-            // Dedupe and determine job detail URLs
+            /**
+             * Collect vacancy detail URLs via the semantic search API.
+             *
+             * DOM pagination in headless Playwright stops around ~100 results; the API exposes the full result set.
+             */
+            const query = scraperTargetConfig.keywords.join(' ');
             const jobDetailUrlSet = new Set<string>();
-
-            const jobDetailUrlPrefix = constants.configuration.detailUrlPrefix;
-            const { maxPages } = scraperTargetConfig;
             let currentPageIndex = 1;
 
-            /**
-             * Re-evaluate each iteration: `maxPages === 0` means unlimited (stop only on URL `break`);
-             * otherwise stop after `goto`/`scrape` for pages `1 … maxPages` (see `finally` increment).
-             */
-            while (maxPages === 0 || currentPageIndex <= maxPages) {
-                /**
-                 * Retry navigation to the search result page up to 3 times with a 1 second delay between attempts.
-                 */
-                try {
-                    await retryWithFixedInterval(
-                        async () => {
-                            await page.goto(buildSearchUrl(scraperTargetConfig.keywords, currentPageIndex));
-                            await page.waitForSelector(constants.selectors.resultsContainer);
-                        },
-                        {
-                            maxAttempts: scraperTargetConfig.totalAttempts,
-                            delayMs: scraperTargetConfig.retryDelayMs,
-                            operationName: 'navigate to search result page',
-                        }
-                    );
+            while (scraperTargetConfig.maxPages === 0 || currentPageIndex <= scraperTargetConfig.maxPages) {
+                const searchPage = await fetchSemanticSearchPage(page, query, currentPageIndex, scraperTargetConfig);
 
-                    /**
-                     * Skip this on page 1: the first results page drops `page=1`
-                     * from the URL even when listings exist, so we would quit too soon.
-                     */
-                    if (currentPageIndex > 1 && !page.url().includes(`page=${currentPageIndex}`)) {
-                        break;
-                    }
-                } catch (error) {
-                    continue;
-                } finally {
-                    // * Note: finally always runs (unless the runtime aborts), so the increment always happens—including on break.
-                    currentPageIndex++;
+                for (const document of searchPage.documents) {
+                    jobDetailUrlSet.add(`${constants.configuration.detailUrlPrefix}${document.id}`);
                 }
 
-                /**
-                 * Resolve attributes with `URL` using the listing document URL as base so
-                 * relative `/en/vacancies/detail/…`-style `href`s are kept; filter by prefix.
-                 */
-                const listingBaseHref = page.url();
-
-                const jobDetailUrls = await page.$$eval(
-                    constants.selectors.itemSelector,
-                    (elements, args) => {
-                        const prefix = args.jobDetailUrlPrefix;
-                        const baseHref = args.listingBaseHref;
-                        const absolute: string[] = [];
-
-                        for (const el of elements) {
-                            try {
-                                const raw = el.getAttribute('href');
-
-                                if (!raw?.trim()) {
-                                    continue;
-                                }
-
-                                const url = new URL(raw.trim(), baseHref);
-
-                                if (url.href.startsWith(prefix)) {
-                                    absolute.push(url.href);
-                                }
-                            } catch {
-                                /* malformed URL, continue to the next one */
-                                continue;
-                            }
-                        }
-
-                        return absolute;
-                    },
-                    {
-                        jobDetailUrlPrefix,
-                        listingBaseHref,
-                    }
-                );
-
-                for (const url of jobDetailUrls) {
-                    jobDetailUrlSet.add(url);
+                if (searchPage.documents.length === 0 || currentPageIndex >= searchPage.numPages) {
+                    break;
                 }
+
+                currentPageIndex += 1;
             }
 
             /**

--- a/backend/src/aop/delegator/tools/scraper/targets/jobs-ch/index.ts
+++ b/backend/src/aop/delegator/tools/scraper/targets/jobs-ch/index.ts
@@ -18,6 +18,161 @@ import { chromium } from 'playwright';
 import { retryWithFixedInterval } from 'utils/async/utils-async-retry';
 
 /**
+ * Parse structured description sections from a jobs.ch description container.
+ *
+ * jobs.ch markup uses alternating section titles (in `p > strong`) and content
+ * blocks (paragraphs or list items). The first direct child of the description
+ * container is a CTA box ("You are a great fit for this position.") which we
+ * skip.
+ */
+export function parseDescriptionSections(
+    containerElement: Element,
+    selectors: {
+        allSpans: string;
+        titleContainer: string;
+        paragraph: string;
+        listItem: string;
+        strong: string;
+    }
+): ScraperDescriptionSection[] {
+    const sections: ScraperDescriptionSection[] = [];
+    let current: ScraperDescriptionSection | null = null;
+
+    const children = Array.from(containerElement.children);
+    let firstChildSkipped = false;
+
+    for (const child of children) {
+        // Skip the first child (CTA box).
+        if (!firstChildSkipped) {
+            firstChildSkipped = true;
+            continue;
+        }
+
+        const spans = Array.from(child.querySelectorAll(selectors.allSpans));
+
+        for (const span of spans) {
+            const text = span.textContent?.trim();
+            if (!text) {
+                continue;
+            }
+
+            /**
+             * Section title: a span whose closest ancestor is `p > strong`.
+             * Finalize the previous section before starting a new one.
+             */
+            if (span.closest(selectors.titleContainer)) {
+                if (current && current.blocks.length > 0) {
+                    sections.push(current);
+                }
+                current = { title: text, blocks: [] };
+                continue;
+            }
+
+            const parentParagraph = span.closest(selectors.paragraph);
+            const parentListItem = span.closest(selectors.listItem);
+
+            /**
+             * Plain paragraph (not a title): a `<p>` that doesn't contain a `<strong>`.
+             */
+            if (parentParagraph && !parentParagraph.querySelector(selectors.strong)) {
+                if (!current) {
+                    current = { blocks: [] };
+                }
+                current.blocks.push(text);
+            } else if (parentListItem) {
+                if (!current) {
+                    current = { blocks: [] };
+                }
+                current.blocks.push(text);
+            }
+        }
+    }
+
+    if (current && current.blocks.length > 0) {
+        sections.push(current);
+    }
+
+    return sections;
+}
+
+/**
+ * Parse label/value information items from a jobs.ch vacancy info container.
+ *
+ * Each list item has 2 text spans — the first is the label, the second the
+ * value. SVG-only spans (icons) are filtered out.
+ */
+export function parseInformationItems(
+    containerElement: Element,
+    selectors: {
+        list: string;
+        listItem: string;
+        span: string;
+        svg: string;
+    }
+): ScraperInformationItem[] {
+    const items: ScraperInformationItem[] = [];
+
+    const list = containerElement.querySelector(selectors.list);
+    if (!list) {
+        return items;
+    }
+
+    const listItems = Array.from(list.querySelectorAll(selectors.listItem));
+
+    for (const listItem of listItems) {
+        const spans = Array.from(listItem.querySelectorAll(selectors.span));
+        const texts: string[] = [];
+
+        for (const span of spans) {
+            const hasSvg = span.querySelector(selectors.svg) !== null;
+            if (hasSvg) {
+                continue;
+            }
+
+            const text = span.textContent?.trim();
+            if (text) {
+                texts.push(text);
+            }
+        }
+
+        if (texts.length >= 2) {
+            items.push({ label: texts[0], value: texts[1] as string });
+        } else if (texts.length === 1) {
+            items.push({ label: '', value: texts[0] as string });
+        }
+    }
+
+    return items;
+}
+
+/**
+ * Extract company name text from a `[data-cy="company-link"]` element.
+ */
+export function parseCompanyNameFromLink(element: Element, spanSelector: string): string | null {
+    const span = element.querySelector(spanSelector);
+    return span?.textContent?.trim() ?? null;
+}
+
+/**
+ * Extract company name text from a `[data-cy="vacancy-logo"]` element,
+ * skipping spans that only contain an SVG logo.
+ */
+export function parseCompanyNameFromVacancyLogo(element: Element, args: { span: string; svg: string }): string | null {
+    const spans = Array.from(element.querySelectorAll(args.span));
+    for (const span of spans) {
+        const hasSvg = span.querySelector(args.svg) !== null;
+        if (hasSvg) {
+            continue;
+        }
+        const text = span.textContent?.trim();
+        if (text) {
+            return text;
+        }
+    }
+    return null;
+}
+
+/**
  * Fetch one page of vacancy IDs from the jobs.ch semantic search API.
  */
 async function fetchSemanticSearchPage(
@@ -80,66 +235,7 @@ async function extractDescriptions(page: Page): Promise<ScraperDescriptionSectio
         return [];
     }
 
-    return container.evaluate((containerElement, selectors) => {
-        const sections: { title?: string; blocks: string[] }[] = [];
-        let current: { title?: string; blocks: string[] } | null = null;
-
-        const children = Array.from(containerElement.children);
-        let firstChildSkipped = false;
-
-        for (const child of children) {
-            // Skip the first child (CTA box).
-            if (!firstChildSkipped) {
-                firstChildSkipped = true;
-                continue;
-            }
-
-            const spans = Array.from(child.querySelectorAll(selectors.allSpans));
-
-            for (const span of spans) {
-                const text = span.textContent?.trim();
-                if (!text) {
-                    continue;
-                }
-
-                /**
-                 * Section title: a span whose closest ancestor is `p > strong`.
-                 * Finalize the previous section before starting a new one.
-                 */
-                if (span.closest(selectors.titleContainer)) {
-                    if (current && current.blocks.length > 0) {
-                        sections.push(current);
-                    }
-                    current = { title: text, blocks: [] };
-                    continue;
-                }
-
-                const parentParagraph = span.closest(selectors.paragraph);
-                const parentListItem = span.closest(selectors.listItem);
-
-                /**
-                 * Plain paragraph (not a title): a `<p>` that doesn't contain a `<strong>`.
-                 */
-                if (parentParagraph && !parentParagraph.querySelector(selectors.strong)) {
-                    if (!current) {
-                        current = { blocks: [] };
-                    }
-                    current.blocks.push(text);
-                } else if (parentListItem) {
-                    if (!current) {
-                        current = { blocks: [] };
-                    }
-                    current.blocks.push(text);
-                }
-            }
-        }
-
-        if (current && current.blocks.length > 0) {
-            sections.push(current);
-        }
-
-        return sections;
-    }, constants.selectors.descriptionParsing);
+    return container.evaluate(parseDescriptionSections, constants.selectors.descriptionParsing);
 }
 
 /**
@@ -155,41 +251,7 @@ async function extractInformations(page: Page): Promise<ScraperInformationItem[]
         return [];
     }
 
-    return container.evaluate((containerElement, selectors) => {
-        const items: ScraperInformationItem[] = [];
-
-        const list = containerElement.querySelector(selectors.list);
-        if (!list) {
-            return items;
-        }
-
-        const listItems = Array.from(list.querySelectorAll(selectors.listItem));
-
-        for (const listItem of listItems) {
-            const spans = Array.from(listItem.querySelectorAll(selectors.span));
-            const texts: string[] = [];
-
-            for (const span of spans) {
-                const hasSvg = span.querySelector(selectors.svg) !== null;
-                if (hasSvg) {
-                    continue;
-                }
-
-                const text = span.textContent?.trim();
-                if (text) {
-                    texts.push(text);
-                }
-            }
-
-            if (texts.length >= 2) {
-                items.push({ label: texts[0], value: texts[1] as string });
-            } else if (texts.length === 1) {
-                items.push({ label: '', value: texts[0] as string });
-            }
-        }
-
-        return items;
-    }, constants.selectors.informationParsing);
+    return container.evaluate(parseInformationItems, constants.selectors.informationParsing);
 }
 
 /**
@@ -205,10 +267,7 @@ async function extractCompanyName(page: Page): Promise<ScraperInformationItem | 
 
     const companyLink = await page.$(constants.selectors.companyNameSelector);
     if (companyLink) {
-        const value = await companyLink.evaluate((element, spanSelector) => {
-            const span = element.querySelector(spanSelector);
-            return span?.textContent?.trim() ?? null;
-        }, parsing.span);
+        const value = await companyLink.evaluate(parseCompanyNameFromLink, parsing.span);
 
         if (value) {
             return { label: parsing.label, value };
@@ -217,23 +276,10 @@ async function extractCompanyName(page: Page): Promise<ScraperInformationItem | 
 
     const vacancyLogo = await page.$(constants.selectors.vacancyLogoSelector);
     if (vacancyLogo) {
-        const value = await vacancyLogo.evaluate(
-            (element, args) => {
-                const spans = Array.from(element.querySelectorAll(args.span)) as HTMLSpanElement[];
-                for (const span of spans) {
-                    const hasSvg = span.querySelector(args.svg) !== null;
-                    if (hasSvg) {
-                        continue;
-                    }
-                    const text = span.textContent?.trim();
-                    if (text) {
-                        return text;
-                    }
-                }
-                return null;
-            },
-            { span: parsing.span, svg: parsing.svg }
-        );
+        const value = await vacancyLogo.evaluate(parseCompanyNameFromVacancyLogo, {
+            span: parsing.span,
+            svg: parsing.svg,
+        });
 
         if (value) {
             return { label: parsing.label, value };

--- a/backend/src/aop/delegator/tools/scraper/targets/jobs-ch/jobs-ch.test.ts
+++ b/backend/src/aop/delegator/tools/scraper/targets/jobs-ch/jobs-ch.test.ts
@@ -2,8 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import constants from './constants';
 
-import type { ScraperTargetConfig } from '../../types';
+import type { ScraperDescriptionSection, ScraperInformationItem, ScraperTargetConfig } from '../../types';
+import type { SemanticSearchResponse } from './types';
 import type { Locator, Page } from 'playwright';
+
+import jobsChTarget from './index';
+import { chromium } from 'playwright';
+import { retryWithFixedInterval } from 'utils/async/utils-async-retry';
 
 vi.mock('utils/async/utils-async-retry', () => ({
     retryWithFixedInterval: vi.fn(async (fn: () => Promise<unknown>) => fn()),
@@ -15,199 +20,589 @@ vi.mock('playwright', () => ({
     },
 }));
 
-import jobsChTarget from './index';
-import { chromium } from 'playwright';
-import { retryWithFixedInterval } from 'utils/async/utils-async-retry';
-
 /**
- * Build a fake Page where each extraction call (textContent, locator(...).evaluate, $)
- * returns canned values. The target reads selectors from constants and dispatches
- * to one of three flows: title (textContent), descriptions/informations (locator
- * evaluate), company name ($-based element handles).
+ * Default {@link ScraperTargetConfig} for jobs-ch target tests.
  */
-const buildPage = (options?: {
-    title?: string | null;
-    descriptions?: { title?: string; blocks: string[] }[];
-    informations?: { label: string; value: string }[];
-    companyLink?: { value: string | null } | null;
-    vacancyLogo?: { value: string | null } | null;
-    /** Return shapes from successive `$$eval` calls (one per listing page visited). */
-    listingDetailUrlBatches?: string[][];
-}): Page => {
-    const titleValue = options?.title ?? 'Engineer';
-    const descriptions = options?.descriptions ?? [];
-    const informations = options?.informations ?? [];
-
-    const descLocator = {
-        count: vi.fn().mockResolvedValue(1),
-        evaluate: vi.fn().mockResolvedValue(descriptions),
-    } as unknown as Locator;
-
-    const infoLocator = {
-        count: vi.fn().mockResolvedValue(1),
-        evaluate: vi.fn().mockResolvedValue(informations),
-    } as unknown as Locator;
-
-    let currentListingPage = 1;
-
-    const listingBatches = options?.listingDetailUrlBatches ?? [
-        ['https://www.jobs.ch/en/vacancies/detail/1'],
-        ['https://www.jobs.ch/en/vacancies/detail/2'],
-    ];
-
-    const $$eval = vi.fn().mockImplementation(() => {
-        const batchIndex = Math.min($$eval.mock.calls.length - 1, listingBatches.length - 1);
-        return Promise.resolve(listingBatches[batchIndex] ?? []);
-    });
-
-    const page = {
-        goto: vi.fn().mockImplementation((u: string) => {
-            const m = u.match(/[?&]page=(\d+)/);
-            if (m && u.includes('vacancies/') && !u.includes('/detail/')) {
-                currentListingPage = Number(m[1]);
-            }
-            return Promise.resolve(undefined);
-        }),
-        url: vi
-            .fn()
-            .mockImplementation(() => `https://www.jobs.ch/en/vacancies/?term=software&page=${currentListingPage}`),
-        $$eval,
-        waitForSelector: vi.fn().mockResolvedValue(undefined),
-        textContent: vi.fn().mockResolvedValue(titleValue),
-        locator: vi.fn().mockImplementation((selector: string) => {
-            if (selector === constants.selectors.descriptionSelector) return descLocator;
-            if (selector === constants.selectors.infoSelector) return infoLocator;
-            return { count: vi.fn().mockResolvedValue(0), evaluate: vi.fn() };
-        }),
-        $: vi.fn().mockImplementation((selector: string) => {
-            if (selector === constants.selectors.companyNameSelector && options?.companyLink) {
-                return {
-                    evaluate: vi.fn().mockResolvedValue(options.companyLink.value),
-                };
-            }
-            if (selector === constants.selectors.vacancyLogoSelector && options?.vacancyLogo) {
-                return {
-                    evaluate: vi.fn().mockResolvedValue(options.vacancyLogo.value),
-                };
-            }
-            return null;
-        }),
-        close: vi.fn().mockResolvedValue(undefined),
-    } as unknown as Page;
-
-    return page;
-};
-
 function buildTargetConfig(overrides?: Partial<ScraperTargetConfig>): ScraperTargetConfig {
     return {
         targetId: 't',
         target: 'jobs-ch',
-        keywords: ['software'],
-        maxPages: 2,
+        keywords: ['frontend'],
+        maxPages: 1,
         totalAttempts: 3,
         retryDelayMs: 1000,
         ...overrides,
     };
 }
 
-async function runTarget(page: Page, overrides?: Partial<ScraperTargetConfig>) {
-    vi.mocked(chromium.launch).mockResolvedValue({
-        newPage: vi.fn().mockResolvedValue(page),
-        close: vi.fn().mockResolvedValue(undefined),
-    } as never);
+/**
+ * Stub `page.request.get` to return paginated semantic-search JSON in call order.
+ */
+function mockSemanticSearchResponse(pages: SemanticSearchResponse[]) {
+    let callIndex = 0;
 
-    return jobsChTarget.run(buildTargetConfig(overrides));
+    return vi.fn(async (url: string) => {
+        const page = pages[callIndex] ?? {
+            documents: [],
+            numPages: pages.length,
+            currentPage: callIndex + 1,
+            totalHits: 0,
+            rows: 20,
+        };
+        callIndex += 1;
+
+        return {
+            ok: () => true,
+            json: async () => page,
+            status: () => 200,
+            url,
+        };
+    });
 }
 
-describe('jobsChTarget', () => {
+/**
+ * Options for {@link buildPage}.
+ */
+type BuildPageOptions = {
+    /** Title text returned from `textContent(titleSelector)`. */
+    title?: string | null;
+    /** When `0`, the description container is treated as absent. */
+    descriptionCount?: number;
+    /** Pre-built sections returned from `descriptionSelector.evaluate`. */
+    descriptions?: ScraperDescriptionSection[];
+    /** When `0`, the info container is treated as absent. */
+    infoCount?: number;
+    /** Pre-built rows returned from `infoSelector.evaluate`. */
+    informations?: ScraperInformationItem[];
+    /** Company name from `[data-cy="company-link"]`. Omit when absent. */
+    companyLink?: string;
+    /** Company name from `[data-cy="vacancy-logo"]` when no company link is set. */
+    vacancyLogo?: string;
+    /** Paginated API payloads consumed by the default `request.get` stub. */
+    semanticSearchPages?: SemanticSearchResponse[];
+    /** Custom `page.request.get` stub; overrides `semanticSearchPages`. */
+    apiGet?: ReturnType<typeof vi.fn>;
+    /** Custom `page.goto` stub. */
+    goto?: ReturnType<typeof vi.fn>;
+    /** Custom `page.waitForSelector` stub. */
+    waitForSelector?: ReturnType<typeof vi.fn>;
+};
+
+/**
+ * Resolve locator `count()` — explicit override, else 1 when content is provided, else 0.
+ */
+function containerCount(explicit: number | undefined, hasContent: boolean): number {
+    if (explicit !== undefined) {
+        return explicit;
+    }
+    return hasContent ? 1 : 0;
+}
+
+/**
+ * Build a fake Playwright {@link Page} wired to jobs.ch selectors.
+ *
+ * Each call to `locator(selector)` returns a stub matched to the extraction
+ * phase (description, info). Company extraction uses `$` + `evaluate` stubs
+ * that return pre-built parser results.
+ */
+const buildPage = (options: BuildPageOptions): Page => {
+    const absentLocator = { count: vi.fn().mockResolvedValue(0), evaluate: vi.fn() };
+
+    const descLocator: Locator = {
+        count: vi.fn().mockResolvedValue(containerCount(options.descriptionCount, options.descriptions !== undefined)),
+        evaluate: vi.fn().mockResolvedValue(options.descriptions ?? []),
+    } as unknown as Locator;
+
+    const infoLocator: Locator = {
+        count: vi.fn().mockResolvedValue(containerCount(options.infoCount, options.informations !== undefined)),
+        evaluate: vi.fn().mockResolvedValue(options.informations ?? []),
+    } as unknown as Locator;
+
+    const companyLinkElement = options.companyLink
+        ? { evaluate: vi.fn().mockResolvedValue(options.companyLink) }
+        : null;
+
+    const vacancyLogoElement =
+        options.vacancyLogo && !options.companyLink
+            ? { evaluate: vi.fn().mockResolvedValue(options.vacancyLogo) }
+            : null;
+
+    const locatorBySelector: Record<string, Locator> = {
+        [constants.selectors.descriptionSelector]: descLocator,
+        [constants.selectors.infoSelector]: infoLocator,
+    };
+
+    const elementBySelector: Record<string, typeof companyLinkElement> = {
+        [constants.selectors.companyNameSelector]: companyLinkElement,
+        [constants.selectors.vacancyLogoSelector]: vacancyLogoElement,
+    };
+
+    const page = {
+        goto: options.goto ?? vi.fn().mockResolvedValue(undefined),
+        request: {
+            get: options.apiGet ?? mockSemanticSearchResponse(options.semanticSearchPages ?? []),
+        },
+        locator: vi.fn().mockImplementation((selector: string) => locatorBySelector[selector] ?? absentLocator),
+        textContent: vi.fn().mockResolvedValue(options.title ?? 'Engineer'),
+        waitForSelector: options.waitForSelector ?? vi.fn().mockResolvedValue(undefined),
+        $: vi.fn().mockImplementation((selector: string) => Promise.resolve(elementBySelector[selector] ?? null)),
+        close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Page;
+
+    return page;
+};
+
+/**
+ * Mock `chromium.launch`, run {@link jobsChTarget}, and return results plus a
+ * `browserClose` spy for lifecycle assertions.
+ */
+async function runTarget(page: Page, overrides?: Partial<ScraperTargetConfig>) {
+    const browserClose = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(chromium.launch).mockResolvedValue({
+        newPage: vi.fn().mockResolvedValue(page),
+        close: browserClose,
+    } as never);
+
+    const results = await jobsChTarget.run(buildTargetConfig(overrides));
+    return { results, browserClose };
+}
+
+describe('jobsChTarget — semantic search discovery', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('joins keywords with spaces in the API query', async () => {
+        const apiGet = mockSemanticSearchResponse([
+            { documents: [{ id: 'a' }], numPages: 1, currentPage: 1, totalHits: 1, rows: 20 },
+        ]);
+        const page = buildPage({
+            semanticSearchPages: [{ documents: [{ id: 'a' }], numPages: 1, currentPage: 1, totalHits: 1, rows: 20 }],
+            apiGet,
+        });
+        await runTarget(page, { keywords: ['react', 'frontend'], maxPages: 1 });
+
+        expect(apiGet).toHaveBeenCalledWith(
+            expect.stringContaining('query=react+frontend'),
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    Accept: 'application/json',
+                    Origin: 'https://www.jobs.ch',
+                    Referer: 'https://www.jobs.ch/',
+                }),
+            })
+        );
+    });
+
+    it('uses fixed rows and page index on the first API call', async () => {
+        const apiGet = mockSemanticSearchResponse([
+            { documents: [{ id: 'a' }], numPages: 1, currentPage: 1, totalHits: 1, rows: 20 },
+        ]);
+        const page = buildPage({ apiGet });
+        await runTarget(page, { maxPages: 1 });
+
+        expect(apiGet).toHaveBeenCalledWith(
+            'https://job-search-api.jobs.ch/search/semantic?query=frontend&rows=20&page=1',
+            expect.any(Object)
+        );
+    });
+
+    it('fetches only one API page when maxPages is 1', async () => {
+        const apiGet = mockSemanticSearchResponse([
+            { documents: [{ id: 'a' }], numPages: 5, currentPage: 1, totalHits: 5, rows: 20 },
+            { documents: [{ id: 'b' }], numPages: 5, currentPage: 2, totalHits: 5, rows: 20 },
+        ]);
+        const page = buildPage({ apiGet });
+        await runTarget(page, { maxPages: 1 });
+
+        expect(apiGet).toHaveBeenCalledTimes(1);
+    });
+
+    it('fetches all pages when maxPages is 0', async () => {
+        const apiGet = mockSemanticSearchResponse([
+            { documents: [{ id: 'a' }], numPages: 3, currentPage: 1, totalHits: 3, rows: 20 },
+            { documents: [{ id: 'b' }], numPages: 3, currentPage: 2, totalHits: 3, rows: 20 },
+            { documents: [{ id: 'c' }], numPages: 3, currentPage: 3, totalHits: 3, rows: 20 },
+        ]);
+        const page = buildPage({ apiGet });
+        await runTarget(page, { maxPages: 0 });
+
+        expect(apiGet).toHaveBeenCalledTimes(3);
+    });
+
+    it('stops when a page returns empty documents', async () => {
+        const apiGet = mockSemanticSearchResponse([
+            { documents: [{ id: 'a' }], numPages: 5, currentPage: 1, totalHits: 5, rows: 20 },
+            { documents: [], numPages: 5, currentPage: 2, totalHits: 5, rows: 20 },
+        ]);
+        const page = buildPage({ apiGet });
+        const { results } = await runTarget(page, { maxPages: 0 });
+
+        expect(apiGet).toHaveBeenCalledTimes(2);
+        expect(results).toHaveLength(1);
+    });
+
+    it('does not request beyond numPages', async () => {
+        const apiGet = mockSemanticSearchResponse([
+            { documents: [{ id: 'a' }], numPages: 2, currentPage: 1, totalHits: 2, rows: 20 },
+            { documents: [{ id: 'b' }], numPages: 2, currentPage: 2, totalHits: 2, rows: 20 },
+        ]);
+        const page = buildPage({ apiGet });
+        await runTarget(page, { maxPages: 0 });
+
+        expect(apiGet).toHaveBeenCalledTimes(2);
+        expect(apiGet).not.toHaveBeenCalledWith(expect.stringContaining('page=3'), expect.any(Object));
+    });
+
+    it('maps document ids to detail URLs', async () => {
+        const apiGet = mockSemanticSearchResponse([
+            { documents: [{ id: 'abc' }], numPages: 1, currentPage: 1, totalHits: 1, rows: 20 },
+        ]);
+        const page = buildPage({ apiGet });
+        const { results } = await runTarget(page, { maxPages: 1 });
+
+        expect(page.goto).toHaveBeenCalledWith('https://www.jobs.ch/en/vacancies/detail/abc');
+        expect(results[0]).toMatchObject({ ok: true, url: 'https://www.jobs.ch/en/vacancies/detail/abc' });
+    });
+
+    it('deduplicates ids across API pages', async () => {
+        const apiGet = mockSemanticSearchResponse([
+            { documents: [{ id: 'dup' }, { id: 'one' }], numPages: 2, currentPage: 1, totalHits: 2, rows: 20 },
+            { documents: [{ id: 'dup' }, { id: 'two' }], numPages: 2, currentPage: 2, totalHits: 2, rows: 20 },
+        ]);
+        const page = buildPage({ apiGet });
+        await runTarget(page, { maxPages: 2 });
+
+        expect(page.goto).toHaveBeenCalledTimes(3);
+    });
+
+    it('returns an empty array when the first API page has no documents', async () => {
+        const apiGet = mockSemanticSearchResponse([
+            { documents: [], numPages: 1, currentPage: 1, totalHits: 0, rows: 20 },
+        ]);
+        const page = buildPage({ apiGet });
+        const { results } = await runTarget(page);
+
+        expect(results).toEqual([]);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('retries the API call totalAttempts times before failing', async () => {
+        vi.mocked(retryWithFixedInterval).mockImplementation(async (fn, options) => {
+            let lastError: Error | undefined;
+            for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
+                try {
+                    return (await fn()) as never;
+                } catch (error) {
+                    lastError = error as Error;
+                }
+            }
+            throw lastError;
+        });
+
+        const apiGet = vi.fn(async () => ({
+            ok: () => false,
+            status: () => 500,
+            json: async () => ({}),
+        }));
+
+        const page = buildPage({ apiGet });
+        const { results } = await runTarget(page, { totalAttempts: 3 });
+
+        expect(apiGet).toHaveBeenCalledTimes(3);
+        expect(results).toHaveLength(1);
+        expect(results[0]).toMatchObject({
+            ok: false,
+            source: 'jobs-ch',
+            url: '',
+            error: { code: 'TARGET_FAILED' },
+        });
+    });
+
+    it('fetches maxPages API pages even when numPages is higher', async () => {
+        const apiGet = mockSemanticSearchResponse([
+            { documents: [{ id: 'p1' }], numPages: 5, currentPage: 1, totalHits: 5, rows: 20 },
+            { documents: [{ id: 'p2' }], numPages: 5, currentPage: 2, totalHits: 5, rows: 20 },
+        ]);
+        const page = buildPage({ apiGet });
+        await runTarget(page, { maxPages: 2 });
+
+        expect(apiGet).toHaveBeenCalledTimes(2);
+        expect(page.goto).toHaveBeenCalledTimes(2);
+    });
+
+    it('deduplicates duplicate ids on the same API page', async () => {
+        const apiGet = mockSemanticSearchResponse([
+            { documents: [{ id: 'dup' }, { id: 'dup' }], numPages: 1, currentPage: 1, totalHits: 2, rows: 20 },
+        ]);
+        const page = buildPage({ apiGet });
+        await runTarget(page);
+
+        expect(page.goto).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('jobsChTarget — detail scrape assembly', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('trims whitespace from the title', async () => {
+        const title = '  Senior Engineer  ';
+        const page = buildPage({
+            title,
+            semanticSearchPages: [{ documents: [{ id: 'a' }], numPages: 1, currentPage: 1, totalHits: 1, rows: 20 }],
+        });
+        const { results } = await runTarget(page);
+
+        expect(results[0]).toMatchObject({ ok: true, title: title.trim() });
+    });
+
+    it('returns an empty title when textContent is null', async () => {
+        const page = buildPage({
+            semanticSearchPages: [{ documents: [{ id: 'a' }], numPages: 1, currentPage: 1, totalHits: 1, rows: 20 }],
+        });
+        vi.mocked(page.textContent).mockRejectedValue(new Error('missing'));
+
+        const { results } = await runTarget(page);
+        expect(results[0]).toMatchObject({ ok: true, title: '' });
+    });
+
+    it('waits for the title selector before extraction', async () => {
+        const waitForSelector = vi.fn().mockResolvedValue(undefined);
+        const page = buildPage({
+            waitForSelector,
+            semanticSearchPages: [{ documents: [{ id: 'a' }], numPages: 1, currentPage: 1, totalHits: 1, rows: 20 }],
+        });
+        await runTarget(page);
+
+        expect(waitForSelector).toHaveBeenCalledWith(constants.selectors.titleSelector);
+    });
+
+    it('assembles a successful listing with text and fields', async () => {
+        const page = buildPage({
+            descriptions: [{ title: 'Tasks', blocks: ['Build features'] }],
+            informations: [{ label: 'Location', value: 'Zurich' }],
+            companyLink: 'Acme AG',
+            semanticSearchPages: [{ documents: [{ id: 'a' }], numPages: 1, currentPage: 1, totalHits: 1, rows: 20 }],
+        });
+        const { results } = await runTarget(page);
+
+        expect(results[0]).toMatchObject({
+            ok: true,
+            source: 'jobs-ch',
+            url: 'https://www.jobs.ch/en/vacancies/detail/a',
+            title: 'Engineer',
+            fields: {
+                Location: 'Zurich',
+                Company: 'Acme AG',
+            },
+        });
+        expect((results[0] as { ok: true; text: string }).text).toContain('Tasks');
+        expect((results[0] as { ok: true; text: string }).text).toContain('Build features');
+        expect((results[0] as { ok: true; text: string }).text).toContain('Location: Zurich');
+        expect((results[0] as { ok: true; text: string }).text).toContain('Company: Acme AG');
+    });
+
+    it('appends Company with empty value when no company element is found', async () => {
+        const page = buildPage({
+            semanticSearchPages: [{ documents: [{ id: 'a' }], numPages: 1, currentPage: 1, totalHits: 1, rows: 20 }],
+        });
+        const { results } = await runTarget(page);
+
+        expect(results[0]).toMatchObject({
+            ok: true,
+            fields: { Company: '' },
+        });
+    });
+
+    it('uses vacancy logo when company link is absent', async () => {
+        const page = buildPage({
+            vacancyLogo: 'Logo Corp',
+            semanticSearchPages: [{ documents: [{ id: 'a' }], numPages: 1, currentPage: 1, totalHits: 1, rows: 20 }],
+        });
+        const { results } = await runTarget(page);
+
+        expect(results[0]).toMatchObject({
+            ok: true,
+            fields: { Company: 'Logo Corp' },
+        });
+    });
+
+    it('returns ok listing with empty text when all extraction containers are absent', async () => {
+        const page = buildPage({
+            descriptionCount: 0,
+            infoCount: 0,
+            semanticSearchPages: [{ documents: [{ id: 'a' }], numPages: 1, currentPage: 1, totalHits: 1, rows: 20 }],
+        });
+        const { results } = await runTarget(page);
+
+        expect(results[0]).toMatchObject({
+            ok: true,
+            title: 'Engineer',
+            text: 'Company: ',
+            fields: { Company: '' },
+        });
+    });
+
+    it('produces one listing per discovered URL', async () => {
+        const page = buildPage({
+            semanticSearchPages: [
+                {
+                    documents: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+                    numPages: 1,
+                    currentPage: 1,
+                    totalHits: 3,
+                    rows: 20,
+                },
+            ],
+        });
+        const { results } = await runTarget(page);
+
+        expect(page.goto).toHaveBeenCalledTimes(3);
+        expect(results).toHaveLength(3);
+        expect(results.every(r => r.ok)).toBe(true);
+    });
+});
+
+describe('jobsChTarget — error handling', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.mocked(retryWithFixedInterval).mockImplementation(async (fn: () => Promise<unknown>) => fn());
     });
 
-    it('paginates listings and emits one result per detail URL', async () => {
-        const page = buildPage();
-        const results = await runTarget(page);
-
-        expect(vi.mocked(page.goto).mock.calls.length).toBeGreaterThanOrEqual(4);
-        const successes = results.filter((r): r is typeof r & { ok: true } => r.ok);
-        expect(successes).toHaveLength(2);
-        expect(successes[0].url).toBe('https://www.jobs.ch/en/vacancies/detail/1');
-        expect(successes[1].url).toBe('https://www.jobs.ch/en/vacancies/detail/2');
-    });
-
-    it('forwards descriptions and informations from the page into text and fields', async () => {
+    it('records NAVIGATION_FAILED and continues scraping remaining URLs', async () => {
+        const goto = vi.fn().mockRejectedValueOnce(new Error('network')).mockResolvedValue(undefined);
         const page = buildPage({
-            descriptions: [{ title: 'Section', blocks: ['line'] }],
-            informations: [{ label: 'Location', value: 'Zurich' }],
-            companyLink: { value: 'Acme' },
-            listingDetailUrlBatches: [['https://www.jobs.ch/en/vacancies/detail/only']],
+            goto,
+            semanticSearchPages: [
+                {
+                    documents: [{ id: 'fail' }, { id: 'ok' }],
+                    numPages: 1,
+                    currentPage: 1,
+                    totalHits: 2,
+                    rows: 20,
+                },
+            ],
         });
-        const results = await runTarget(page, { maxPages: 1 });
 
-        const listing = results.find((r): r is typeof r & { ok: true } => r.ok);
-        expect(listing?.fields?.Location).toBe('Zurich');
-        expect(listing?.fields?.Company).toBe('Acme');
-        expect(listing?.text).toContain('Section');
-        expect(listing?.text).toContain('line');
-        expect(listing?.text).toContain('Location: Zurich');
-    });
-
-    it('falls back to vacancy-logo for company name when company-link is missing', async () => {
-        const page = buildPage({
-            companyLink: null,
-            vacancyLogo: { value: 'LogoCompany' },
-            listingDetailUrlBatches: [['https://www.jobs.ch/en/vacancies/detail/only']],
-        });
-        const results = await runTarget(page, { maxPages: 1 });
-
-        const listing = results.find((r): r is typeof r & { ok: true } => r.ok);
-        expect(listing?.fields?.Company).toBe('LogoCompany');
-    });
-
-    it('emits an empty company value when no company markup is present', async () => {
-        const page = buildPage({
-            companyLink: null,
-            vacancyLogo: null,
-            listingDetailUrlBatches: [['https://www.jobs.ch/en/vacancies/detail/only']],
-        });
-        const results = await runTarget(page, { maxPages: 1 });
-
-        const listing = results.find((r): r is typeof r & { ok: true } => r.ok);
-        expect(listing?.fields?.Company).toBe('');
-    });
-
-    it('records an error when navigating to a detail page fails after retries', async () => {
-        let retryCall = 0;
-        vi.mocked(retryWithFixedInterval).mockImplementation(async (fn: () => Promise<unknown>) => {
-            retryCall += 1;
-            // 1 = listing page 1, 2 = listing page 2, 3 = first detail URL — fail that one.
-            if (retryCall === 3) {
-                throw new Error('navigation failed');
+        vi.mocked(retryWithFixedInterval).mockImplementation(async (fn, options) => {
+            let lastError: Error | undefined;
+            for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
+                try {
+                    return (await fn()) as never;
+                } catch (error) {
+                    lastError = error as Error;
+                }
             }
-            return fn();
+            throw lastError;
         });
 
-        const page = buildPage();
-        const results = await runTarget(page);
+        const { results } = await runTarget(page, { totalAttempts: 1 });
 
-        const failures = results.filter((r): r is typeof r & { ok: false } => !r.ok);
-        expect(failures).toHaveLength(1);
-        expect(failures[0].error.message).toContain('Failed to navigate to job detail page');
-        expect(failures[0].error.message).toContain('https://www.jobs.ch/en/vacancies/detail/1');
+        expect(results).toHaveLength(2);
+        expect(results[0]).toMatchObject({
+            ok: false,
+            url: 'https://www.jobs.ch/en/vacancies/detail/fail',
+            error: { code: 'NAVIGATION_FAILED' },
+        });
+        expect(results[1]).toMatchObject({ ok: true });
     });
 
-    it('passes item selector and detail URL prefix into listing $$eval', async () => {
-        const page = buildPage({ listingDetailUrlBatches: [['https://www.jobs.ch/en/vacancies/detail/abc']] });
-        await runTarget(page, { maxPages: 1 });
+    it('records SCRAPE_FAILED when detail extraction throws', async () => {
+        const waitForSelector = vi.fn().mockRejectedValue(new Error('timeout'));
+        const page = buildPage({
+            waitForSelector,
+            semanticSearchPages: [{ documents: [{ id: 'a' }], numPages: 1, currentPage: 1, totalHits: 1, rows: 20 }],
+        });
+        const { results } = await runTarget(page);
 
-        expect(page.$$eval).toHaveBeenCalledWith(
-            constants.selectors.itemSelector,
-            expect.any(Function),
-            expect.objectContaining({
-                jobDetailUrlPrefix: constants.configuration.detailUrlPrefix,
-                listingBaseHref: expect.any(String),
-            })
-        );
+        expect(results[0]).toMatchObject({
+            ok: false,
+            error: { code: 'SCRAPE_FAILED' },
+        });
+    });
+
+    it('returns mixed results for nav fail, scrape fail, and success', async () => {
+        const urls = [
+            'https://www.jobs.ch/en/vacancies/detail/nav-fail',
+            'https://www.jobs.ch/en/vacancies/detail/scrape-fail',
+            'https://www.jobs.ch/en/vacancies/detail/ok',
+        ];
+        let gotoCount = 0;
+        const goto = vi.fn().mockImplementation(async (url: string) => {
+            gotoCount += 1;
+            if (url.includes('nav-fail')) {
+                throw new Error('nav');
+            }
+        });
+
+        let scrapeAttempts = 0;
+        const waitForSelector = vi.fn().mockImplementation(async () => {
+            scrapeAttempts += 1;
+            if (scrapeAttempts === 1) {
+                throw new Error('scrape');
+            }
+        });
+
+        const page = buildPage({
+            goto,
+            waitForSelector,
+            semanticSearchPages: [
+                {
+                    documents: [{ id: 'nav-fail' }, { id: 'scrape-fail' }, { id: 'ok' }],
+                    numPages: 1,
+                    currentPage: 1,
+                    totalHits: 3,
+                    rows: 20,
+                },
+            ],
+        });
+
+        vi.mocked(retryWithFixedInterval).mockImplementation(async (fn, options) => {
+            let lastError: Error | undefined;
+            for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
+                try {
+                    return (await fn()) as never;
+                } catch (error) {
+                    lastError = error as Error;
+                }
+            }
+            throw lastError;
+        });
+
+        const { results } = await runTarget(page, { totalAttempts: 1 });
+
+        expect(gotoCount).toBe(3);
+        expect(results).toHaveLength(3);
+        expect(results.filter(r => !r.ok).map(r => (r as { error: { code: string } }).error.code)).toEqual([
+            'NAVIGATION_FAILED',
+            'SCRAPE_FAILED',
+        ]);
+        expect(results[2]).toMatchObject({ ok: true, url: urls[2] });
+    });
+
+    it('propagates when browser launch throws', async () => {
+        vi.mocked(chromium.launch).mockRejectedValue(new Error('launch failed'));
+        await expect(jobsChTarget.run(buildTargetConfig())).rejects.toThrow('launch failed');
+    });
+
+    it('always closes the browser and page', async () => {
+        const pageClose = vi.fn().mockResolvedValue(undefined);
+        const browserClose = vi.fn().mockResolvedValue(undefined);
+        const page = buildPage({
+            semanticSearchPages: [{ documents: [{ id: 'a' }], numPages: 1, currentPage: 1, totalHits: 1, rows: 20 }],
+        });
+        page.close = pageClose;
+
+        vi.mocked(chromium.launch).mockResolvedValue({
+            newPage: vi.fn().mockResolvedValue(page),
+            close: browserClose,
+        } as never);
+
+        await jobsChTarget.run(buildTargetConfig());
+
+        expect(pageClose).toHaveBeenCalled();
+        expect(browserClose).toHaveBeenCalled();
     });
 });

--- a/backend/src/aop/delegator/tools/scraper/targets/jobs-ch/types/index.ts
+++ b/backend/src/aop/delegator/tools/scraper/targets/jobs-ch/types/index.ts
@@ -1,0 +1,19 @@
+/**
+ * A semantic search document from the jobs.ch API.
+ */
+interface SemanticSearchDocument {
+    id: string;
+}
+
+/**
+ * A semantic search response from the jobs.ch API.
+ */
+interface SemanticSearchResponse {
+    documents: SemanticSearchDocument[];
+    numPages: number;
+    currentPage: number;
+    totalHits: number;
+    rows: number;
+}
+
+export type { SemanticSearchResponse };

--- a/backend/src/aop/scheduler/index.ts
+++ b/backend/src/aop/scheduler/index.ts
@@ -210,7 +210,7 @@ export class Scheduler {
      */
     public schedule(payload: SchedulePayload): void {
         const jobId = payload.jobId;
-        const startDate = new Date(payload.startDate);
+        const startDate = new Date(payload.startDate); // startDate = nextRun or a startDate in the future validated by the controller
         const endDate = payload.endDate ? new Date(payload.endDate) : null;
         const now = new Date();
 

--- a/backend/src/server/index.ts
+++ b/backend/src/server/index.ts
@@ -13,8 +13,12 @@ import config from 'config';
 
 import { initializeDatabase } from './server-initialize-db';
 
-// TODO: Cap maxPages to X for the scraper tool if we expose the application to users.
+// TODO: 1. Add stop job endpoint and logic.
+// TODO: 2. Add job pipeline information streaming.
 
+// TODO: Production: Look into capping the maxPages for the scraper tool.
+
+// TODO: Monitor
 // TODO: (node:25) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
 // TODO: (Use `node --trace-deprecation ...` to show where the warning was created)
 


### PR DESCRIPTION
Fixes jobs.ch scraper discovery by calling the semantic search API instead of paginating listing pages in headless Playwright, which only returned ~100 results, caused incomplete pagination, and could loop indefinitely on the old URL-based pagination logic.