### PR TITLE
feat/tkt-ui-001-add-shadcn-toast

### DIFF
--- a/.agents/skills/writing-docs/SKILL.md
+++ b/.agents/skills/writing-docs/SKILL.md
@@ -22,15 +22,16 @@ Keep product docs concise, precise, and readable — correct layer, stable IDs, 
 # Doc stack
 
 ```text
-FR / NFR  →  Architecture acceptance (HTTP, Client)  →  Implementation  →  Tests
+FR / NFR  →  Tickets (docs/tickets)  →  Architecture acceptance (HTTP, Client)  →  Implementation  →  Tests
 ```
 
 - **FR / NFR** — `docs/specs/requirements/` — what / how well
+- **Tickets** — `docs/tickets/` — work slices (story + DoD); not status tracking
 - **HTTP** — `docs/specs/architecture/http/` — API scenarios
 - **Client** — `docs/specs/architecture/client/` — UI scenarios
 - **Guides** — `docs/guides/software-docs/` — how the stack works
 
-Change control: **FR/NFR first → acceptance → tests and implementation.**
+Change control: **FR/NFR first → acceptance → tests and implementation.** Tickets organize work; they do not replace FRs.
 
 Canonical detail: layer READMEs under those paths; traceability in `docs/guides/software-docs/software-requirements-specification.md`.
 

--- a/docs/guides/software-docs/software-documentation.md
+++ b/docs/guides/software-docs/software-documentation.md
@@ -21,10 +21,10 @@ The goal is to make every requirement clear, measurable, and testable.
 ## 2. Agile Artifacts
 **Answers:** *What work needs to be completed next?*
 
-Agile artifacts break the SRS into manageable pieces of work.
+Agile artifacts break the SRS into manageable pieces of work. Docs: [`docs/tickets/`](../../tickets/).
 
 - **User Stories** describe functionality from the user's perspective.
-- **Acceptance Criteria** define the exact conditions that must be met for the work to be considered complete.
+- **Definition of done** (acceptance for the work slice) defines when the ticket is complete.
 
 These are planning and execution tools—not replacements for the SRS.
 

--- a/docs/tickets/README.md
+++ b/docs/tickets/README.md
@@ -1,0 +1,66 @@
+# Tickets
+
+Work slices that break the SRS into implementable units. Not a status board — no open/done fields. Completion lives in git / PRs.
+
+For FR / HTTP / CLIENT IDs, prose, and where a behavior belongs in the SRS stack, follow [`.agents/skills/writing-docs/SKILL.md`](../../.agents/skills/writing-docs/SKILL.md).
+
+## Layout
+
+```text
+docs/tickets/
+├── README.md
+└── <domain>/
+    └── tkt-<domain>-###-<slug>.md
+```
+
+- One ticket per file
+- Domain folder matches the ID domain (`ui`, `jobs`, `auth`, …)
+- Filename: lowercase id + short kebab slug
+
+## ID
+
+`TKT-<DOMAIN>-###` — e.g. `TKT-UI-001`
+
+Per-domain sequence. Next free only. Never renumber. Retired IDs stay unused.
+
+## Labels
+
+Purpose only. Inline after the title:
+
+| Label | Use |
+|-------|-----|
+| `feature` | New or extended product behavior |
+| `fix` | Correct broken behavior |
+| `chore` | Non-user-facing / shared infrastructure |
+| `docs` | Specs or guides only |
+| `spike` | Time-boxed investigation |
+
+## Shape
+
+```markdown
+# TKT-<DOMAIN>-### — Short title
+
+Labels: `feature`
+
+## User story
+
+As a …, I want … so that ….
+
+## Definition of done
+
+- [ ] …
+- [ ] …
+
+## Traces
+
+- [FR-…](../../specs/requirements/…)
+```
+
+- **User story** — one short As a / I want / so that (or equivalent)
+- **DoD** — checklist for this slice; link acceptance scenarios instead of rewriting them
+- **Traces** — relative links to FR (required when product-facing); HTTP/CLIENT when relevant (see writing-docs skill)
+- No status, assignees, or estimates in the body
+
+## Domains
+
+- [ui](./ui/)

--- a/docs/tickets/ui/tkt-ui-001-shadcn-toast.md
+++ b/docs/tickets/ui/tkt-ui-001-shadcn-toast.md
@@ -1,0 +1,30 @@
+# TKT-UI-001 — Add shadcn Toast
+
+Labels: `feature`
+
+## User story
+
+As a user, I want brief toast feedback for actions so that I can see success, info, warning, error, and loading outcomes without leaving the page.
+
+## Definition of done
+
+- [x] [shadcn Toast](https://ui.shadcn.com/docs/components/base/toast) primitives live in `frontend/src/components/ui/toast.tsx`
+- [x] App wrapper in `frontend/src/components/ui-app/toast/` with status icons below
+- [x] `<Toaster />` is mounted once in the app root (`App.tsx`)
+- [x] Callers use `toast` from `@/components/ui-app/toast/Toast`
+- [x] Types render with the status icons below (coloured as noted)
+
+### Status icons
+
+| Type | Icon |
+|------|------|
+| (default) | none |
+| `success` | green tick in a circle (`CircleCheckIcon`) |
+| `info` | muted `i` in a circle (`InfoIcon`) |
+| `warning` | loudspeaker / horn (`MegaphoneIcon`) |
+| `error` | red X in a circle (`CircleXIcon`) |
+| `loading` | [`Spinner`](../../../frontend/src/components/ui-app/spinner/Spinner.tsx) with `type="circle"` |
+
+## Traces
+
+None — shared UI; product flows that emit toasts cite their own FR/CLIENT scenarios.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter } from 'react-router-dom';
 
 import AppSetup from '@/components/container/appSetup/AppSetup';
 import Routes from '@/components/routing/routes/Routes';
+import { Toaster } from '@/components/ui-app/toast/Toast';
 
 import './stylesheets/global.css';
 
@@ -23,9 +24,11 @@ import './stylesheets/global.css';
 const App = () => {
     return (
         <AppSetup>
-            <BrowserRouter>
-                <Routes />
-            </BrowserRouter>
+            <Toaster>
+                <BrowserRouter>
+                    <Routes />
+                </BrowserRouter>
+            </Toaster>
         </AppSetup>
     );
 };

--- a/frontend/src/components/pages/jobs/components/jobsList/components/shared/components/actionButton/ActionButton.tsx
+++ b/frontend/src/components/pages/jobs/components/jobsList/components/shared/components/actionButton/ActionButton.tsx
@@ -109,10 +109,10 @@ const ActionButton = ({
 
     const actionToVariantMap = {
         stop: 'destructive',
-        pause: 'primary',
-        activate: 'warning',
+        pause: 'warning',
+        activate: 'success',
         run: 'primary',
-        retry: 'destructive',
+        retry: 'primary',
     } as const satisfies Record<ActionType, 'primary' | 'destructive' | 'warning' | 'success'>;
 
     const actionToLabelMap = {

--- a/frontend/src/components/ui-app/toast/Toast.test.tsx
+++ b/frontend/src/components/ui-app/toast/Toast.test.tsx
@@ -1,0 +1,59 @@
+import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { ToastType } from './Toast.types';
+
+import { toast, Toaster } from './Toast';
+
+const addToast = (options: Parameters<typeof toast.add>[0] & { type?: ToastType }) => {
+    act(() => {
+        toast.add({ timeout: 0, ...options });
+    });
+};
+
+describe('Toaster', () => {
+    afterEach(() => {
+        act(() => {
+            toast.close();
+        });
+        cleanup();
+    });
+
+    it('shows title and description when a toast is added', async () => {
+        render(<Toaster />);
+        addToast({ title: 'Saved', description: 'Job created' });
+
+        const notification = await screen.findByRole('dialog', { name: 'Saved' });
+        expect(within(notification).getByText('Job created')).toBeInTheDocument();
+    });
+
+    it('shows a loading status for loading toasts', async () => {
+        render(<Toaster />);
+        addToast({ type: 'loading', title: 'Working…' });
+
+        const notification = await screen.findByRole('dialog', { name: 'Working…' });
+        expect(within(notification).getByRole('status', { name: 'Loading' })).toBeInTheDocument();
+    });
+
+    it('does not show a loading status for default toasts', async () => {
+        render(<Toaster />);
+        addToast({ title: 'Notice' });
+
+        const notification = await screen.findByRole('dialog', { name: 'Notice' });
+        expect(within(notification).queryByRole('status')).not.toBeInTheDocument();
+    });
+
+    it('closes the toast when the close control is activated', async () => {
+        render(<Toaster />);
+        addToast({ title: 'Dismiss me' });
+
+        const notification = await screen.findByRole('dialog', { name: 'Dismiss me' });
+        // Base UI marks Toast.Close aria-hidden, so include hidden nodes until the primitive exposes it.
+        await userEvent.click(within(notification).getByRole('button', { hidden: true }));
+
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog', { name: 'Dismiss me' })).not.toBeInTheDocument();
+        });
+    });
+});

--- a/frontend/src/components/ui-app/toast/Toast.tsx
+++ b/frontend/src/components/ui-app/toast/Toast.tsx
@@ -1,0 +1,60 @@
+import type { ToasterProps, ToastType } from './Toast.types';
+
+import ToastIcon from './ToastIcon';
+import {
+    Toast,
+    toast as toastManager,
+    ToastAction,
+    ToastClose,
+    ToastContent,
+    ToastDescription,
+    ToastPortal,
+    ToastProvider,
+    ToastTitle,
+    ToastViewport,
+    useToastManager,
+} from '@/components/ui/toast';
+
+function ToastList() {
+    const { toasts } = useToastManager();
+
+    return toasts.map(toastItem => (
+        <Toast key={toastItem.id} toast={toastItem}>
+            <ToastContent>
+                <ToastIcon type={toastItem.type} />
+                <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    <ToastTitle />
+                    <ToastDescription />
+                </div>
+                {toastItem.actionProps ? <ToastAction /> : null}
+                <ToastClose />
+            </ToastContent>
+        </Toast>
+    ));
+}
+
+/**
+ * App toast shell — mounts the Base UI toast provider and viewport once.
+ */
+function Toaster({ children }: ToasterProps) {
+    return (
+        <ToastProvider toastManager={toastManager}>
+            {children}
+            <ToastPortal>
+                <ToastViewport>
+                    <ToastList />
+                </ToastViewport>
+            </ToastPortal>
+        </ToastProvider>
+    );
+}
+
+const toast = {
+    add: (options: Parameters<typeof toastManager.add>[0] & { type?: ToastType }) => toastManager.add(options),
+    close: toastManager.close.bind(toastManager),
+    update: toastManager.update.bind(toastManager),
+    promise: toastManager.promise.bind(toastManager),
+};
+
+export { toast, Toaster };
+export type { ToastType };

--- a/frontend/src/components/ui-app/toast/Toast.tsx
+++ b/frontend/src/components/ui-app/toast/Toast.tsx
@@ -1,6 +1,7 @@
+import ToastIcon from './toastIcon/ToastIcon';
+
 import type { ToasterProps, ToastType } from './Toast.types';
 
-import ToastIcon from './ToastIcon';
 import {
     Toast,
     toast as toastManager,

--- a/frontend/src/components/ui-app/toast/Toast.types.ts
+++ b/frontend/src/components/ui-app/toast/Toast.types.ts
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react';
+
+type ToastType = 'success' | 'info' | 'warning' | 'error' | 'loading';
+
+type ToastIconProps = {
+    type?: string;
+};
+
+type ToasterProps = {
+    children?: ReactNode;
+};
+
+export type { ToastType, ToastIconProps, ToasterProps };

--- a/frontend/src/components/ui-app/toast/Toast.types.ts
+++ b/frontend/src/components/ui-app/toast/Toast.types.ts
@@ -2,12 +2,8 @@ import type { ReactNode } from 'react';
 
 type ToastType = 'success' | 'info' | 'warning' | 'error' | 'loading';
 
-type ToastIconProps = {
-    type?: string;
-};
-
 type ToasterProps = {
     children?: ReactNode;
 };
 
-export type { ToastType, ToastIconProps, ToasterProps };
+export type { ToastType, ToasterProps };

--- a/frontend/src/components/ui-app/toast/ToastIcon.tsx
+++ b/frontend/src/components/ui-app/toast/ToastIcon.tsx
@@ -1,0 +1,51 @@
+import { CircleCheckIcon, CircleXIcon, InfoIcon, MegaphoneIcon } from 'lucide-react';
+
+import Spinner from '@/components/ui-app/spinner/Spinner';
+
+import type { ToastIconProps, ToastType } from './Toast.types';
+import type { ReactNode } from 'react';
+
+import { cn } from '@/lib/utils';
+
+const iconClassName = "shrink-0 [&_svg:not([class*='size-'])]:size-4";
+
+const toastIcons: Record<ToastType, { icon: ReactNode; className?: string }> = {
+    success: {
+        icon: <CircleCheckIcon aria-hidden="true" />,
+        className: 'text-success',
+    },
+    info: {
+        icon: <InfoIcon aria-hidden="true" />,
+        className: 'text-muted-foreground',
+    },
+    warning: {
+        icon: <MegaphoneIcon aria-hidden="true" />,
+        className: 'text-warning',
+    },
+    error: {
+        icon: <CircleXIcon aria-hidden="true" />,
+        className: 'text-destructive',
+    },
+    loading: {
+        icon: <Spinner type="circle" size="s" className="size-4" aria-hidden="true" />,
+    },
+};
+
+/**
+ * Status icon for a toast type. Default (undefined / unknown) renders nothing.
+ */
+const ToastIcon = ({ type }: ToastIconProps) => {
+    if (!type || !(type in toastIcons)) {
+        return null;
+    }
+
+    const { icon, className } = toastIcons[type as ToastType];
+
+    return (
+        <span data-slot="toast-icon" className={cn(iconClassName, className)}>
+            {icon}
+        </span>
+    );
+};
+
+export default ToastIcon;

--- a/frontend/src/components/ui-app/toast/toastIcon/ToastIcon.test.tsx
+++ b/frontend/src/components/ui-app/toast/toastIcon/ToastIcon.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { ToastType } from '../Toast.types';
+
+import ToastIcon from './ToastIcon';
+
+describe('ToastIcon', () => {
+    it.each(['success', 'info', 'warning', 'error'] as ToastType[])('renders an icon for type "%s"', type => {
+        const { container } = render(<ToastIcon type={type} />);
+        expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('renders a loading status for type "loading"', () => {
+        render(<ToastIcon type="loading" />);
+        expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
+    });
+
+    it('renders nothing when type is omitted', () => {
+        const { container } = render(<ToastIcon />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing for an unknown type', () => {
+        const { container } = render(<ToastIcon type="unknown" />);
+        expect(container).toBeEmptyDOMElement();
+    });
+});

--- a/frontend/src/components/ui-app/toast/toastIcon/ToastIcon.tsx
+++ b/frontend/src/components/ui-app/toast/toastIcon/ToastIcon.tsx
@@ -2,7 +2,8 @@ import { CircleCheckIcon, CircleXIcon, InfoIcon, MegaphoneIcon } from 'lucide-re
 
 import Spinner from '@/components/ui-app/spinner/Spinner';
 
-import type { ToastIconProps, ToastType } from './Toast.types';
+import type { ToastType } from '../Toast.types';
+import type { ToastIconProps } from './ToastIcon.types';
 import type { ReactNode } from 'react';
 
 import { cn } from '@/lib/utils';

--- a/frontend/src/components/ui-app/toast/toastIcon/ToastIcon.types.ts
+++ b/frontend/src/components/ui-app/toast/toastIcon/ToastIcon.types.ts
@@ -1,0 +1,5 @@
+type ToastIconProps = {
+    type?: string;
+};
+
+export type { ToastIconProps };

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -1,0 +1,136 @@
+import { Toast as ToastPrimitive } from '@base-ui/react/toast';
+import { XIcon } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+const toast = ToastPrimitive.createToastManager();
+
+function ToastProvider({ ...props }: ToastPrimitive.Provider.Props) {
+    return <ToastPrimitive.Provider {...props} />;
+}
+
+function ToastPortal({ ...props }: ToastPrimitive.Portal.Props) {
+    return <ToastPrimitive.Portal data-slot="toast-portal" {...props} />;
+}
+
+function ToastViewport({ className, ...props }: ToastPrimitive.Viewport.Props) {
+    return (
+        <ToastPrimitive.Viewport
+            data-slot="toast-viewport"
+            className={cn(
+                'pointer-events-none fixed inset-x-4 bottom-4 z-50 mx-auto w-auto max-w-sm outline-none sm:right-4 sm:left-auto sm:mx-0 sm:w-full',
+                className
+            )}
+            {...props}
+        />
+    );
+}
+
+function Toast({ className, ...props }: ToastPrimitive.Root.Props) {
+    return (
+        <ToastPrimitive.Root
+            data-slot="toast"
+            className={cn(
+                'group/toast pointer-events-auto absolute right-0 bottom-0 z-[calc(1000-var(--toast-index))] w-full origin-bottom rounded-2xl border bg-popover text-popover-foreground shadow-lg will-change-transform outline-none select-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50',
+                '[--gap:0.75rem] [--height:var(--toast-frontmost-height,var(--toast-height))] [--offset-y:calc(var(--toast-offset-y)*-1+calc(var(--toast-index)*var(--gap)*-1)+var(--toast-swipe-movement-y))] [--peek:0.75rem] [--scale:calc(max(0,1-(var(--toast-index)*0.1)))] [--shrink:calc(1-var(--scale))]',
+                'h-(--height) [transform:translateX(var(--toast-swipe-movement-x))_translateY(calc(var(--toast-swipe-movement-y)-(var(--toast-index)*var(--peek))-(var(--shrink)*var(--height))))_scale(var(--scale))] [transition:transform_500ms_cubic-bezier(0.22,1,0.36,1),opacity_500ms,height_150ms]',
+                "after:absolute after:top-full after:left-0 after:h-[calc(var(--gap)+1px)] after:w-full after:content-['']",
+                'data-expanded:h-(--toast-height) data-expanded:[transform:translateX(var(--toast-swipe-movement-x))_translateY(var(--offset-y))]',
+                'data-limited:opacity-0 data-starting-style:[transform:translateY(150%)]',
+                '[&[data-ending-style]:not([data-limited]):not([data-swipe-direction])]:[transform:translateY(150%)]',
+                'data-ending-style:data-[swipe-direction=down]:[transform:translateY(calc(var(--toast-swipe-movement-y)+150%))]',
+                'data-ending-style:data-[swipe-direction=left]:[transform:translateX(calc(var(--toast-swipe-movement-x)-150%))_translateY(var(--offset-y))]',
+                'data-ending-style:data-[swipe-direction=right]:[transform:translateX(calc(var(--toast-swipe-movement-x)+150%))_translateY(var(--offset-y))]',
+                'data-ending-style:data-[swipe-direction=up]:[transform:translateY(calc(var(--toast-swipe-movement-y)-150%))]',
+                'data-expanded:data-ending-style:data-[swipe-direction=down]:[transform:translateY(calc(var(--toast-swipe-movement-y)+150%))]',
+                'data-expanded:data-ending-style:data-[swipe-direction=left]:[transform:translateX(calc(var(--toast-swipe-movement-x)-150%))_translateY(var(--offset-y))]',
+                'data-expanded:data-ending-style:data-[swipe-direction=right]:[transform:translateX(calc(var(--toast-swipe-movement-x)+150%))_translateY(var(--offset-y))]',
+                'data-expanded:data-ending-style:data-[swipe-direction=up]:[transform:translateY(calc(var(--toast-swipe-movement-y)-150%))]',
+                className
+            )}
+            {...props}
+        />
+    );
+}
+
+function ToastContent({ className, ...props }: ToastPrimitive.Content.Props) {
+    return (
+        <ToastPrimitive.Content
+            data-slot="toast-content"
+            className={cn(
+                'flex h-full items-center gap-3 overflow-hidden p-4 transition-opacity duration-250 ease-[cubic-bezier(0.22,1,0.36,1)] data-behind:opacity-0 data-expanded:opacity-100',
+                className
+            )}
+            {...props}
+        />
+    );
+}
+
+function ToastTitle({ className, ...props }: ToastPrimitive.Title.Props) {
+    return <ToastPrimitive.Title data-slot="toast-title" className={cn('text-sm font-medium', className)} {...props} />;
+}
+
+function ToastDescription({ className, ...props }: ToastPrimitive.Description.Props) {
+    return (
+        <ToastPrimitive.Description
+            data-slot="toast-description"
+            className={cn('text-sm text-muted-foreground', className)}
+            {...props}
+        />
+    );
+}
+
+function ToastAction({
+    className,
+    render = <Button variant="outline" size="sm" />,
+    ...props
+}: ToastPrimitive.Action.Props) {
+    return (
+        <ToastPrimitive.Action
+            data-slot="toast-action"
+            render={render}
+            className={cn('shrink-0', className)}
+            {...props}
+        />
+    );
+}
+
+function ToastClose({
+    className,
+    children,
+    render = <Button variant="ghost" size="icon-sm" />,
+    ...props
+}: ToastPrimitive.Close.Props) {
+    return (
+        <ToastPrimitive.Close
+            data-slot="toast-close"
+            aria-label="Close toast"
+            render={render}
+            className={cn(
+                "relative shrink-0 text-muted-foreground after:absolute after:-inset-2 after:content-[''] hover:text-foreground",
+                className
+            )}
+            {...props}>
+            {children ?? <XIcon aria-hidden="true" />}
+        </ToastPrimitive.Close>
+    );
+}
+
+const createToastManager = ToastPrimitive.createToastManager;
+const useToastManager = ToastPrimitive.useToastManager;
+
+export {
+    createToastManager,
+    toast,
+    Toast,
+    ToastAction,
+    ToastClose,
+    ToastContent,
+    ToastDescription,
+    ToastPortal,
+    ToastProvider,
+    ToastTitle,
+    ToastViewport,
+    useToastManager,
+};


### PR DESCRIPTION
Added a shadcn/Base UI toast, wrapped in ui-app with success, info, warning, error, and loading icons (loading uses the circle Spinner). See tickethttps://github.com/g-rosuson/fullstack-dashboard/actions